### PR TITLE
Added configs for XP & fatigue drops

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,8 @@
 - *[Command Key]* + n - Toggle NPC info
 - *[Command Key]* + p - Toggle Player info
 - *[Command Key]* + h - Toggle hitboxes for NPC info
+- *[Command Key]* + [ - Toggle XP drops
+- *[Command Key]* + ] - Toggle fatigue drops
 - *[Command Key]* + 1-5 - World switch on login screen
 
 ## Chat Commands
@@ -81,6 +83,10 @@
 *::toggleplayerinfo* - Toggle Player info
 
 *::togglehitbox* - Toggle hitboxes for NPC info
+
+*::togglexpdrops* - Toggle XP drops
+
+*::togglefatiguedrops* - Toggle fatigue drops
 
 *::fov* - Change FoV from 8-9
 
@@ -119,6 +125,10 @@
   <dt>view_distance</dt>
   <dd>Range: <i>2,300 to 10,000</i><br>
   Sets max render distance of structures and landscape</dd>
+  
+  <dt>fatigue_figures</dt>
+  <dd>Range: <i>1 to 7</i><br>
+  Sets max number of digits to display after the decimal point on fatigue drops</dd>
 </dl>
   
 ### Automatically configured via user input in game

--- a/README.md
+++ b/README.md
@@ -178,6 +178,14 @@
   <dt>show_logindetails</dt>
   <dd>Range: <i>true or false</i><br>
   Sets whether login details such as IP or DNS will appear at the login screen</dd>
+
+  <dt>show_xpdrops</dt>
+  <dd>Range: <i>true or false</i><br>
+  Sets whether XP drops appear on screen</dd>
+  
+  <dt>show_fatiguedrops</dt>
+  <dd>Range: <i>true or false</i><br>
+  Sets whether fatigue drops appear on screen</dd>
   
   <dt>twitch_hide</dt>
   <dd>Range: <i>true or false</i><br>

--- a/readme.txt
+++ b/readme.txt
@@ -28,6 +28,8 @@ Mouse wheel scroll - Zoom camera
 [Command Key] + n - Toggle NPC info
 [Command Key] + p - Toggle Player info
 [Command Key] + h - Toggle hitboxes for NPC info
+[Command Key] + [ - Toggle XP drops
+[Command Key] + ] - Toggle fatigue drops
 [Command Key] + 1-5 - World switch on login screen
 
 ~ Chat Commands
@@ -44,4 +46,6 @@ Mouse wheel scroll - Zoom camera
 ::togglenpcinfo - Toggle NPC info
 ::toggleplayerinfo - Toggle Player info
 ::togglehitbox - Toggle hitboxes for NPC info
+::togglexpdrops - Toggle XP drops
+::togglefatiguedrops - Toggle fatigue drops
 ::fov - Change FoV from 8-9

--- a/src/Client/Settings.java
+++ b/src/Client/Settings.java
@@ -71,6 +71,8 @@ public class Settings
 			SHOW_PLAYERINFO = getBoolean(props, "show_playerinfo", false);
 			SHOW_HITBOX = getBoolean(props, "show_hitbox", false);
 			SHOW_LOGINDETAILS = getBoolean(props, "show_logindetails", false);
+			SHOW_XPDROPS = getBoolean(props, "show_xpdrops", true);
+			SHOW_FATIGUEDROPS = getBoolean(props, "show_fatiguedrops", true);
 			SOFTWARE_CURSOR = getBoolean(props, "software_cursor", false);
 			DEBUG = getBoolean(props, "debug", false);
 			VIEW_DISTANCE = getInt(props, "view_distance", 10000);
@@ -82,6 +84,7 @@ public class Settings
 			TWITCH_CHANNEL = getString(props, "twitch_channel", "");
 			NAME_PATCH_TYPE = getInt(props, "name_patch_type", 3);
 			SAVE_LOGININFO = getBoolean(props, "save_logininfo", true);
+			FATIGUE_FIGURES = getInt(props, "fatigue_figures", 2);
 
 			if(WORLD < 1)
 				WORLD = 1;
@@ -114,6 +117,11 @@ public class Settings
 				NAME_PATCH_TYPE = 0;
 			else if(NAME_PATCH_TYPE > 3)
 				NAME_PATCH_TYPE = 3;
+			
+			if(FATIGUE_FIGURES < 1)
+				FATIGUE_FIGURES = 1;
+			else if(FATIGUE_FIGURES > 7)
+				FATIGUE_FIGURES = 7;
 		}
 		catch(Exception e) {}
 
@@ -137,6 +145,8 @@ public class Settings
 			props.setProperty("show_playerinfo", "" + SHOW_PLAYERINFO);
 			props.setProperty("show_hitbox", "" + SHOW_HITBOX);
 			props.setProperty("show_logindetails", "" + SHOW_LOGINDETAILS);
+			props.setProperty("show_xpdrops", "" + SHOW_XPDROPS);
+			props.setProperty("show_fatiguedrops", "" + SHOW_FATIGUEDROPS);
 			props.setProperty("software_cursor", "" + SOFTWARE_CURSOR);
 			props.setProperty("debug", "" + DEBUG);
 			props.setProperty("view_distance", "" + VIEW_DISTANCE);
@@ -148,6 +158,7 @@ public class Settings
 			props.setProperty("twitch_channel", "" + TWITCH_CHANNEL);
 			props.setProperty("name_patch_type", "" + NAME_PATCH_TYPE);
 			props.setProperty("save_logininfo", "" + SAVE_LOGININFO);
+			props.setProperty("fatigue_figures", "" + FATIGUE_FIGURES);
 
 			FileOutputStream out = new FileOutputStream(Dir.JAR + "/config.ini");
 			props.store(out, "---rscplus config---");
@@ -304,6 +315,26 @@ public class Settings
 			Client.displayMessage("@cya@Twitch chat is now shown", Client.CHAT_NONE);
 		Save();
 	}
+	
+	public static void toggleXpDrops()
+	{
+		SHOW_XPDROPS = !SHOW_XPDROPS;
+		if(SHOW_XPDROPS)
+			Client.displayMessage("@cya@XP drops are now shown", Client.CHAT_NONE);
+		else
+			Client.displayMessage("@cya@XP drops are now hidden", Client.CHAT_NONE);
+		Save();
+	}
+	
+	public static void toggleFatigueDrops()
+	{
+		SHOW_FATIGUEDROPS = !SHOW_FATIGUEDROPS;
+		if(SHOW_FATIGUEDROPS)
+			Client.displayMessage("@cya@Fatigue drops are now shown", Client.CHAT_NONE);
+		else
+			Client.displayMessage("@cya@Fatigue drops are now hidden", Client.CHAT_NONE);
+		Save();
+	}
 
 	private static String getString(Properties props, String key, String def)
 	{
@@ -376,6 +407,8 @@ public class Settings
 	public static boolean SHOW_ITEMINFO = false;
 	public static boolean SHOW_HITBOX = false;
 	public static boolean SHOW_LOGINDETAILS = false;
+	public static boolean SHOW_XPDROPS = true;
+	public static boolean SHOW_FATIGUEDROPS = true;
 	public static boolean SOFTWARE_CURSOR = false;
 	public static boolean DEBUG = false;
 	public static boolean TWITCH_HIDE = false;
@@ -384,4 +417,5 @@ public class Settings
 	public static String TWITCH_CHANNEL = "";
 	public static int NAME_PATCH_TYPE = 3;
 	public static boolean SAVE_LOGININFO = true;
+	public static int FATIGUE_FIGURES = 2;
 }

--- a/src/Game/Client.java
+++ b/src/Game/Client.java
@@ -21,16 +21,15 @@
 
 package Game;
 
-import Client.Logger;
-import Client.Settings;
-import Client.TwitchIRC;
 import java.applet.Applet;
 import java.io.BufferedWriter;
 import java.io.File;
 import java.io.FileWriter;
-import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.List;
+
+import Client.Settings;
+import Client.TwitchIRC;
 
 public class Client {
 
@@ -80,7 +79,8 @@ public class Client {
 				xpdrop_state[i] += xpGain;
 
 				if (xpGain > 0.0f && dropXP) {
-					xpdrop_handler.add("+" + xpGain + " (" + skill_name[i] + ")");
+					if (Settings.SHOW_XPDROPS)
+						xpdrop_handler.add("+" + xpGain + " (" + skill_name[i] + ")");
 
 					if (i == SKILL_HP && xpbar.currentSkill != -1)
 						continue;
@@ -89,11 +89,13 @@ public class Client {
 				}
 			}
 			// + Fatigue drops
-			final float actualFatigue = (float) (fatigue * 100.0 / 750);
-			final float fatigueGain = actualFatigue - currentFatigue;
-			if (fatigueGain > 0.0f) {
-				xpdrop_handler.add("+" + fatigueGain + "% (Fatigue)");
-				currentFatigue = actualFatigue;
+			if(Settings.SHOW_FATIGUEDROPS) {
+				final float actualFatigue = (float) (fatigue * 100.0 / 750);
+				final float fatigueGain = actualFatigue - currentFatigue;
+				if (fatigueGain > 0.0f) {
+					xpdrop_handler.add("+" + trimNumber(fatigueGain,Settings.FATIGUE_FIGURES) + "% (Fatigue)");
+					currentFatigue = actualFatigue;
+				}
 			}
 		}
 	}
@@ -202,6 +204,10 @@ public class Client {
 				Renderer.takeScreenshot();
 			else if (command.equals("debug"))
 				Settings.toggleDebug();
+			else if (command.equals("togglexpdrops"))
+				Settings.toggleXpDrops();
+			else if (command.equals("togglefatiguedrops"))
+				Settings.toggleFatigueDrops();
 			else if (command.equals("fov") && commandArray.length > 1)
 				Camera.setFoV(Integer.parseInt(commandArray[1]));
 
@@ -332,6 +338,10 @@ public class Client {
 
 	public static int getFatigue() {
 		return (fatigue * 100 / 750);
+	}
+	
+	public static Double trimNumber(double num, int figures) {
+		return Math.round(num*Math.pow(10,figures))/Math.pow(10,figures);
 	}
 
 	public static void updateCurrentFatigue() {

--- a/src/Game/Client.java
+++ b/src/Game/Client.java
@@ -90,13 +90,16 @@ public class Client {
 			}
 			// + Fatigue drops
 			if(Settings.SHOW_FATIGUEDROPS) {
-				final float actualFatigue = (float) (fatigue * 100.0 / 750);
+				final float actualFatigue = getActualFatigue();
 				final float fatigueGain = actualFatigue - currentFatigue;
-				if (fatigueGain > 0.0f) {
+				if (fatigueGain > 0.0f && !isWelcomeScreen()) {
 					xpdrop_handler.add("+" + trimNumber(fatigueGain,Settings.FATIGUE_FIGURES) + "% (Fatigue)");
 					currentFatigue = actualFatigue;
 				}
 			}
+			// Prevents a fatigue drop upon first login during a session
+			if(isWelcomeScreen() && currentFatigue != getActualFatigue())
+				currentFatigue = getActualFatigue();
 		}
 	}
 
@@ -339,13 +342,17 @@ public class Client {
 	public static int getFatigue() {
 		return (fatigue * 100 / 750);
 	}
+
+	public static float getActualFatigue() {
+		return (float) (fatigue * 100.0 / 750);
+	}
 	
 	public static Double trimNumber(double num, int figures) {
 		return Math.round(num*Math.pow(10,figures))/Math.pow(10,figures);
 	}
 
 	public static void updateCurrentFatigue() {
-		final float nextFatigue = (float) (fatigue * 100.0 / 750);
+		final float nextFatigue = getActualFatigue();
 		if (currentFatigue != nextFatigue) {
 			currentFatigue = nextFatigue;
 		}

--- a/src/Game/KeyboardHandler.java
+++ b/src/Game/KeyboardHandler.java
@@ -68,6 +68,12 @@ public class KeyboardHandler implements KeyListener
 
 			if(command_key == KeyEvent.VK_P)
 				Settings.toggleShowPlayerInfo();
+			
+			if(command_key == KeyEvent.VK_OPEN_BRACKET)
+				Settings.toggleXpDrops();
+			
+			if(command_key == KeyEvent.VK_CLOSE_BRACKET)
+				Settings.toggleFatigueDrops();
 
 			if(Client.state == Client.STATE_LOGIN)
 			{


### PR DESCRIPTION
- XP and fatigue drops are now toggled via commands or keyboard shortcuts
- The max number of digits shown past the decimal can be changed for fatigue drops (default is 2)
- Fixed a bug where the current fatigue is displayed as a fatigue drop when logging in for the first time during a session
- Updated README to reflect changes