### PR TITLE
XP/Hr + Actions until Level Calculator

### DIFF
--- a/src/Game/Client.java
+++ b/src/Game/Client.java
@@ -82,6 +82,22 @@ public class Client {
 					if (Settings.SHOW_XPDROPS)
 						xpdrop_handler.add("+" + xpGain + " (" + skill_name[i] + ")");
 
+					// XP/hr calculations
+					// TODO: After 5-10 minutes of tracking XP, make it display a rolling average instead of a session average
+					if((System.currentTimeMillis() - lastXpGain[i][1]) <= 180000) {
+					// < 3 minutes since last XP drop
+						lastXpGain[i][0] = xpGain + lastXpGain[i][0];
+						XpPerHour[i] = 3600 * (lastXpGain[i][0]) / ((System.currentTimeMillis() - lastXpGain[i][2]) / 1000);
+						lastXpGain[i][3]++;
+						showXpPerHour[i] = true;
+						lastXpGain[i][1] = System.currentTimeMillis();
+					} else {
+						lastXpGain[i][0] = xpGain;
+						lastXpGain[i][1] = lastXpGain[i][2] = System.currentTimeMillis();
+						lastXpGain[i][3] = 0;
+						showXpPerHour[i] = false;
+					}
+					
 					if (i == SKILL_HP && xpbar.currentSkill != -1)
 						continue;
 
@@ -502,4 +518,11 @@ public class Client {
 	private static MouseHandler handler_mouse;
 	private static KeyboardHandler handler_keyboard;
 	private static float xpdrop_state[] = new float[18];
+	
+	public static boolean showXpPerHour[] = new boolean[18];
+	public static double XpPerHour[] = new double[18];
+	
+	// [[skill1, skill2, skill3, ...], [totalXpGainInSample, mostRecentXpDropTime, initialTimeInSample, sampleSize]]
+	// sampleSize is unnecessary until estimating XP drops until level, etc.
+	public static double lastXpGain[][] = new double[18][4];
 }

--- a/src/Game/Client.java
+++ b/src/Game/Client.java
@@ -523,6 +523,6 @@ public class Client {
 	public static double XpPerHour[] = new double[18];
 	
 	// [[skill1, skill2, skill3, ...], [totalXpGainInSample, mostRecentXpDropTime, initialTimeInSample, sampleSize]]
-	// sampleSize is unnecessary until estimating XP drops until level, etc.
+	// sampleSize + 1 is the actual sample size
 	public static double lastXpGain[][] = new double[18][4];
 }

--- a/src/Game/XPBar.java
+++ b/src/Game/XPBar.java
@@ -85,14 +85,20 @@ public class XPBar
 			y = MouseHandler.y + 16;
 			g.setColor(Renderer.color_gray);
 			Renderer.setAlpha(g, 0.5f);
-			g.fillRect(x - 100, y, 200, 60);
+			if(Client.showXpPerHour[currentSkill])
+				g.fillRect(x - 100, y, 200, 72);
+			else
+				g.fillRect(x - 100, y, 200, 60);
 			Renderer.setAlpha(g, 1.0f);
 
+			// TODO: Format numbers with commas and round as appropriate
 			y += 8;
 			Renderer.drawShadowText(g, Client.skill_name[currentSkill], x, y, Renderer.color_text, true); y += 12;
 			Renderer.drawShadowText(g, "Level: " + Client.current_level[currentSkill] + "/" + Client.base_level[currentSkill], x, y, Renderer.color_text, true); y += 12;
 			Renderer.drawShadowText(g, "XP: " + Client.getXP(currentSkill), x, y, Renderer.color_text, true); y += 12;
 			Renderer.drawShadowText(g, "XP until Level: " + Client.getXPUntilLevel(currentSkill), x, y, Renderer.color_text, true); y += 12;
+			if(Client.showXpPerHour[currentSkill])
+				Renderer.drawShadowText(g, "XP/Hr: " + Math.round(Client.XpPerHour[currentSkill]), x, y, Renderer.color_text, true); y += 12;
 		}
 
 		Renderer.setAlpha(g, 1.0f);

--- a/src/Game/XPBar.java
+++ b/src/Game/XPBar.java
@@ -87,16 +87,18 @@ public class XPBar
 			g.setColor(Renderer.color_gray);
 			Renderer.setAlpha(g, 0.5f);
 			if(Client.showXpPerHour[currentSkill])
-				g.fillRect(x - 100, y, 200, 48);
+				g.fillRect(x - 100, y, 200, 60);
 			else
 				g.fillRect(x - 100, y, 200, 36);
 			Renderer.setAlpha(g, 1.0f);
 
 			y += 8;
 			Renderer.drawShadowText(g, "XP: " + formatXP(Client.getXP(currentSkill)), x, y, Renderer.color_text, true); y += 12;
-			Renderer.drawShadowText(g, "XP to Level: " + formatXP(Client.getXPUntilLevel(currentSkill)), x, y, Renderer.color_text, true); y += 12;
-			if(Client.showXpPerHour[currentSkill])
+			Renderer.drawShadowText(g, "XP until Level: " + formatXP(Client.getXPUntilLevel(currentSkill)), x, y, Renderer.color_text, true); y += 12;
+			if(Client.showXpPerHour[currentSkill]) {
 				Renderer.drawShadowText(g, "XP/Hr: " + formatXP(Client.XpPerHour[currentSkill]), x, y, Renderer.color_text, true); y += 12;
+				Renderer.drawShadowText(g, "Actions until Level: " + formatXP( Client.getXPUntilLevel(currentSkill) / (Client.lastXpGain[currentSkill][0]/(Client.lastXpGain[currentSkill][3] + 1)) ), x, y, Renderer.color_text, true); y += 12;
+			}
 		}
 
 		Renderer.setAlpha(g, 1.0f);

--- a/src/Game/XPBar.java
+++ b/src/Game/XPBar.java
@@ -23,6 +23,7 @@ package Game;
 
 import java.awt.Dimension;
 import java.awt.Graphics2D;
+import java.text.NumberFormat;
 
 public class XPBar
 {
@@ -86,22 +87,23 @@ public class XPBar
 			g.setColor(Renderer.color_gray);
 			Renderer.setAlpha(g, 0.5f);
 			if(Client.showXpPerHour[currentSkill])
-				g.fillRect(x - 100, y, 200, 72);
+				g.fillRect(x - 100, y, 200, 48);
 			else
-				g.fillRect(x - 100, y, 200, 60);
+				g.fillRect(x - 100, y, 200, 36);
 			Renderer.setAlpha(g, 1.0f);
 
-			// TODO: Format numbers with commas and round as appropriate
 			y += 8;
-			Renderer.drawShadowText(g, Client.skill_name[currentSkill], x, y, Renderer.color_text, true); y += 12;
-			Renderer.drawShadowText(g, "Level: " + Client.current_level[currentSkill] + "/" + Client.base_level[currentSkill], x, y, Renderer.color_text, true); y += 12;
-			Renderer.drawShadowText(g, "XP: " + Client.getXP(currentSkill), x, y, Renderer.color_text, true); y += 12;
-			Renderer.drawShadowText(g, "XP until Level: " + Client.getXPUntilLevel(currentSkill), x, y, Renderer.color_text, true); y += 12;
+			Renderer.drawShadowText(g, "XP: " + formatXP(Client.getXP(currentSkill)), x, y, Renderer.color_text, true); y += 12;
+			Renderer.drawShadowText(g, "XP to Level: " + formatXP(Client.getXPUntilLevel(currentSkill)), x, y, Renderer.color_text, true); y += 12;
 			if(Client.showXpPerHour[currentSkill])
-				Renderer.drawShadowText(g, "XP/Hr: " + Math.round(Client.XpPerHour[currentSkill]), x, y, Renderer.color_text, true); y += 12;
+				Renderer.drawShadowText(g, "XP/Hr: " + formatXP(Client.XpPerHour[currentSkill]), x, y, Renderer.color_text, true); y += 12;
 		}
 
 		Renderer.setAlpha(g, 1.0f);
+	}
+	
+	public static String formatXP(double number) {
+		return NumberFormat.getIntegerInstance().format(Math.round(number));
 	}
 
 	public int currentSkill;


### PR DESCRIPTION
- The XP bar tooltip displays the XP/hr and Actions until level up
- The XP/hr calculation appears after a skill has received 2 XP drops and will continue showing as a tooltip until the skill has not been trained for 3 minutes, after which the XP/hr is reset for that skill
- The Actions until level up calculator uses the average of the XP drops received for that skill recently, not just the last XP drop's value
- Redundant information in the XP bar tooltip has been removed
- The numbers in the XP bar tooltip have been reformatted to be rounded and formatted with commas or the regional standard of the user