### PR TITLE
Fixed crash on internet disconnect

### DIFF
--- a/src/Client/Settings.java
+++ b/src/Client/Settings.java
@@ -42,7 +42,7 @@ public class Settings
 	//Internally used variables
 	public static boolean fovUpdateRequired;
 	public static boolean versionCheckRequired = true;
-	public static double VERSION_NUMBER = 20161018.070624;
+	public static double VERSION_NUMBER = 20170116.130322;
 		//The version number ^^^^ follows ISO 8601 yyyyMMdd.HHmmss
 		//The version number will actually be read from this source file, so please don't change the name of this variable and keep the assignment near the top for scanning.
 		//This variable can be set automatically by ant by issuing `ant setversion`

--- a/src/Client/Util.java
+++ b/src/Client/Util.java
@@ -98,7 +98,7 @@ public class Util
 					is.close();
 			}
 			catch(IOException e) {}
-			return null;
+			return worldPopArray;
 		}
 
 		String line = null;


### PR DESCRIPTION
The world population fetching caused a crash if the client was unable to reach the RuneScape webpage with the world population on it.