### PR TITLE
Fix crashing bug

### DIFF
--- a/src/Game/Renderer.java
+++ b/src/Game/Renderer.java
@@ -208,7 +208,7 @@ public class Renderer {
 
 				if (Settings.SHOW_ITEMINFO) { //don't sort if we aren't displaying any item names anyway
 					try {
-						Collections.sort(Client.item_list, new ItemComparator()); //keep items in (technically reverse) alphabetical order for SHOW_ITEMINFO instead of randomly changing pla$
+						Collections.sort(Client.item_list, new ItemComparator()); //keep items in (technically reverse) alphabetical order for SHOW_ITEMINFO instead of randomly changing places each frame
 					} catch (Exception e) { //Sometimes Java helpfully complains that the sorting method violates its general contract.
 						e.printStackTrace();
 					}

--- a/src/Game/Renderer.java
+++ b/src/Game/Renderer.java
@@ -206,7 +206,13 @@ public class Renderer {
 				List<Rectangle> item_hitbox = new ArrayList<Rectangle>();
 				List<Point> item_text_loc = new ArrayList<Point>();
 
-				Collections.sort(Client.item_list, new ItemComparator()); //keep items in (technically reverse) alphabetical order for SHOW_ITEMINFO instead of randomly changing places each frame
+				if (Settings.SHOW_ITEMINFO) { //don't sort if we aren't displaying any item names anyway
+					try {
+						Collections.sort(Client.item_list, new ItemComparator()); //keep items in (technically reverse) alphabetical order for SHOW_ITEMINFO instead of randomly changing pla$
+					} catch (Exception e) { //Sometimes Java helpfully complains that the sorting method violates its general contract.
+						e.printStackTrace();
+					}
+				}
 
 				for (Iterator<Item> iterator = Client.item_list.iterator(); iterator.hasNext();) {
 					Item item = iterator.next();


### PR DESCRIPTION
Some rare bug where my item sorting method "violates its general contract" causes the program to crash still. Thought it got fixed, but it still happens. This commit stops the item list from being sorted when there's no reason to, and also wraps the sort function in a generous try catch block. In a worst case scenario, instead of crashing, it should show the item names unsorted for a couple frames now.