### PR TITLE
Console log improvement and bugfix

### DIFF
--- a/src/Game/Client.java
+++ b/src/Game/Client.java
@@ -29,11 +29,9 @@ import java.io.BufferedWriter;
 import java.io.File;
 import java.io.FileWriter;
 import java.io.InputStreamReader;
-import java.io.UnsupportedEncodingException;
 import java.net.URL;
 import java.net.URLConnection;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 
 import org.fusesource.jansi.AnsiConsole;

--- a/src/Game/Client.java
+++ b/src/Game/Client.java
@@ -29,9 +29,11 @@ import java.io.BufferedWriter;
 import java.io.File;
 import java.io.FileWriter;
 import java.io.InputStreamReader;
+import java.io.UnsupportedEncodingException;
 import java.net.URL;
 import java.net.URLConnection;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 import org.fusesource.jansi.AnsiConsole;
@@ -468,7 +470,9 @@ public class Client {
 	// All messages added to chat are routed here
 	public static void messageHook(String username, String message, int type) {
 		if (username != null)
-			username = username.replace("\u00A0", " "); //Prevents non-breaking space in colored usernames appearing as á in console
+			username = username.replace("\u00A0", " "); //Prevents non-breaking space in colored usernames appearing as an accented 'a' in console
+		if (message != null)
+			message = message.replace("\u00A0", " ");   //Prevents non-breaking space in colored usernames appearing as an accented 'a' in console
 		if (type == CHAT_NONE) {
 			if (username == null && message != null) {
 				if(message.contains("The spell fails! You may try again in 20 seconds"))

--- a/src/Game/Client.java
+++ b/src/Game/Client.java
@@ -449,7 +449,7 @@ public class Client {
 		}
 		catch(Exception e)
 		{
-			displayMessage("@dre@error checking for update",0);
+			displayMessage("@dre@Error checking latest version",0);
 			//System.out.println(e);
 			return Settings.VERSION_NUMBER;
 		}
@@ -536,6 +536,7 @@ public class Client {
 	}
 
 	public static String colorizeUsername(String colorMessage, int type) {
+		colorMessage = colorMessage.replace("\u00A0", " "); //Prevents non-breaking space in usernames appearing as á
 		switch (type) {
 			case CHAT_PRIVATE:
 				colorMessage = "@|cyan,intensity_bold "  + colorMessage + " tells you: |@"; //Username tells you:

--- a/src/Game/Client.java
+++ b/src/Game/Client.java
@@ -467,6 +467,8 @@ public class Client {
 
 	// All messages added to chat are routed here
 	public static void messageHook(String username, String message, int type) {
+		if (username != null)
+			username = username.replace("\u00A0", " "); //Prevents non-breaking space in colored usernames appearing as á in console
 		if (type == CHAT_NONE) {
 			if (username == null && message != null) {
 				if(message.contains("The spell fails! You may try again in 20 seconds"))
@@ -528,30 +530,60 @@ public class Client {
 
 		if (Settings.COLORIZE) { //no nonsense for those who don't want it
 			AnsiConsole.systemInstall();
-			System.out.println(ansi().render("@|white (" + type + ")|@ " + ((username == null) ? "" : colorizeUsername(username, type)) + colorizeMessage(message, type)));
+			System.out.println(ansi().render("@|white (" + type + ")|@ " + ((username == null) ? "" : colorizeUsername(formatUsername(username, type), type)) + colorizeMessage(message, type)));
 			AnsiConsole.systemUninstall();
 		} else {
-			System.out.println("(" + type + ") " + ((username == null) ? "" : username + ": ") + message);
+			System.out.println("(" + type + ") " + ((username == null) ? "" : formatUsername(username, type)) + message);
 		}
 	}
 
-	public static String colorizeUsername(String colorMessage, int type) {
-		colorMessage = colorMessage.replace("\u00A0", " "); //Prevents non-breaking space in usernames appearing as á
+	private static String formatUsername(String username, int type) {
 		switch (type) {
 			case CHAT_PRIVATE:
-				colorMessage = "@|cyan,intensity_bold "  + colorMessage + " tells you: |@"; //Username tells you:
+				username = username + " tells you: "; // Username tells you:
 				break;
 			case CHAT_PRIVATE_OUTGOING:
-				colorMessage = "@|cyan,intensity_bold You tell " + colorMessage + ": |@"; //You tell Username:
+				username = "You tell " + username + ": "; // You tell Username:
 				break;
 			case CHAT_QUEST:
-				colorMessage = "@|white,intensity_faint " + colorMessage + ": |@"; //If username != null during CHAT_QUEST, then this is your player name, which is usually white
+				username = username + ": "; // If username != null during CHAT_QUEST, then this is your player name
 				break;
 			case CHAT_CHAT:
-				colorMessage = "@|yellow,intensity_bold " + colorMessage + ": |@"; //just bold username for chat
+				username = username + ": ";
+				break;
+			case CHAT_PLAYER_INTERACT_IN: // happens when player trades you
+				username = username + " wishes to trade with you.";
+				break;
+			/* username will not appear in these chat types, but just to cover it I'm leaving code commented out here
+			case CHAT_NONE:
+			case CHAT_PRIVATE_LOG_IN_OUT:
+			case CHAT_PLAYER_INTERRACT_OUT:
+			*/
+	
+			default:
+				System.out.println("Username specified for unhandled chat type, please report this: " + type);
+				username = username + ": ";
+		}
+
+		return username;
+	}
+
+	public static String colorizeUsername(String colorMessage, int type) {
+		switch (type) {
+			case CHAT_PRIVATE:
+				colorMessage = "@|cyan,intensity_bold "  + colorMessage + "|@"; //Username tells you:
+				break;
+			case CHAT_PRIVATE_OUTGOING:
+				colorMessage = "@|cyan,intensity_bold " + colorMessage + "|@"; //You tell Username:
+				break;
+			case CHAT_QUEST:
+				colorMessage = "@|white,intensity_faint " + colorMessage + "|@"; //If username != null during CHAT_QUEST, then this is your player name, which is usually white
+				break;
+			case CHAT_CHAT:
+				colorMessage = "@|yellow,intensity_bold " + colorMessage + "|@"; //just bold username for chat
 				break;
 			case CHAT_PLAYER_INTERACT_IN: //happens when player trades you
-				colorMessage = "@|white " + colorMessage + " wishes to trade with you.|@";
+				colorMessage = "@|white " + colorMessage + "|@";
 				break;
 			/*// username will not appear in these chat types, but just to cover it I'm leaving code commented out here
 			case CHAT_NONE:
@@ -561,7 +593,7 @@ public class Client {
 
 			default:
 				System.out.println("Username specified for unhandled chat type, please report this: " + type);
-				colorMessage = "@|white,intensity_bold " + colorMessage + ": |@";
+				colorMessage = "@|white,intensity_bold " + colorMessage + "|@";
 		}
 		return colorMessage;
 	}


### PR DESCRIPTION
### The improvement:
Previously, the colored and uncolored PMs wrote slightly different text to the console. They are now consistent with each other.

### The bugfix:
In the colored console log, usernames with spaces appeared as a `á`:
**Before:**
![image](https://cloud.githubusercontent.com/assets/2666891/22830209/7b291208-ef5a-11e6-991d-5a6f2ff2d6bf.png)
**After:** 
![image](https://cloud.githubusercontent.com/assets/2666891/22830376/241d1b0c-ef5b-11e6-806a-d6129002a5cf.png)