### PR TITLE
Added the option to center the position of the XP progress bar.

### DIFF
--- a/src/Client/ConfigWindow.java
+++ b/src/Client/ConfigWindow.java
@@ -426,8 +426,10 @@ public class ConfigWindow {
 		generalPanelXPDropsCheckbox.setToolTipText("Show the XP gained as an overlay each time XP is received");
 		
 			ButtonGroup XPAlignButtonGroup = new ButtonGroup();
-			generalPanelXPRightAlignFocusButton = addRadioButton("Display XP bar to the right", generalPanel, 20);
-			generalPanelXPCenterAlignFocusButton = addRadioButton("Display XP bar in the center", generalPanel, 20);
+			generalPanelXPRightAlignFocusButton = addRadioButton("Display on the right", generalPanel, 20);
+			generalPanelXPRightAlignFocusButton.setToolTipText("The XP bar and XP drops will be shown just left of the Settings menu.");
+			generalPanelXPCenterAlignFocusButton = addRadioButton("Display in the center", generalPanel, 20);
+			generalPanelXPCenterAlignFocusButton.setToolTipText("TThe XP bar and XP drops will be shown at the top-middle of the screen.");
 			XPAlignButtonGroup.add(generalPanelXPRightAlignFocusButton);
 			XPAlignButtonGroup.add(generalPanelXPCenterAlignFocusButton);
 

--- a/src/Client/ConfigWindow.java
+++ b/src/Client/ConfigWindow.java
@@ -121,6 +121,8 @@ public class ConfigWindow {
 	private JCheckBox generalPanelChatHistoryCheckbox;
 	private JCheckBox generalPanelCombatXPMenuCheckbox;
 	private JCheckBox generalPanelXPDropsCheckbox;
+		private JRadioButton generalPanelXPCenterAlignFocusButton;
+		private JRadioButton generalPanelXPRightAlignFocusButton;
 	private JCheckBox generalPanelFatigueDropsCheckbox;
 	private JSpinner generalPanelFatigueFigSpinner;
 	private JCheckBox generalPanelFatigueAlertCheckbox;
@@ -423,6 +425,12 @@ public class ConfigWindow {
 		generalPanelXPDropsCheckbox = addCheckbox("XP drops", generalPanel);
 		generalPanelXPDropsCheckbox.setToolTipText("Show the XP gained as an overlay each time XP is received");
 		
+			ButtonGroup XPAlignButtonGroup = new ButtonGroup();
+			generalPanelXPRightAlignFocusButton = addRadioButton("Display XP bar to the right", generalPanel, 20);
+			generalPanelXPCenterAlignFocusButton = addRadioButton("Display XP bar in the center", generalPanel, 20);
+			XPAlignButtonGroup.add(generalPanelXPRightAlignFocusButton);
+			XPAlignButtonGroup.add(generalPanelXPCenterAlignFocusButton);
+
 		generalPanelFatigueDropsCheckbox = addCheckbox("Fatigue drops", generalPanel);
 		generalPanelFatigueDropsCheckbox.setToolTipText("Show the fatigue gained as an overlay each time fatigue is received");
 		
@@ -1049,6 +1057,10 @@ public class ConfigWindow {
 		generalPanelChatHistoryCheckbox.setSelected(Settings.LOAD_CHAT_HISTORY); 			// TODO: Implement this feature
 		generalPanelCombatXPMenuCheckbox.setSelected(Settings.COMBAT_MENU);
 		generalPanelXPDropsCheckbox.setSelected(Settings.SHOW_XPDROPS);
+		generalPanelXPCenterAlignFocusButton.setSelected(Settings.CENTER_XPDROPS);
+		generalPanelXPRightAlignFocusButton.setSelected(!Settings.CENTER_XPDROPS);
+		notificationPanelTrayPopupClientFocusButton.setSelected(!Settings.TRAY_NOTIFS_ALWAYS);
+		notificationPanelTrayPopupAnyFocusButton.setSelected(Settings.TRAY_NOTIFS_ALWAYS);
 		generalPanelFatigueDropsCheckbox.setSelected(Settings.SHOW_FATIGUEDROPS);
 		generalPanelFatigueFigSpinner.setValue(new Integer(Settings.FATIGUE_FIGURES));
 		generalPanelFatigueAlertCheckbox.setSelected(Settings.FATIGUE_ALERT);
@@ -1131,6 +1143,7 @@ public class ConfigWindow {
 		Settings.LOAD_CHAT_HISTORY = generalPanelChatHistoryCheckbox.isSelected();
 		Settings.COMBAT_MENU = generalPanelCombatXPMenuCheckbox.isSelected();
 		Settings.SHOW_XPDROPS = generalPanelXPDropsCheckbox.isSelected();
+		Settings.CENTER_XPDROPS = generalPanelXPCenterAlignFocusButton.isSelected();
 		Settings.SHOW_FATIGUEDROPS = generalPanelFatigueDropsCheckbox.isSelected();
 		Settings.FATIGUE_FIGURES = ((SpinnerNumberModel)(generalPanelFatigueFigSpinner.getModel())).getNumber().intValue();
 		Settings.FATIGUE_ALERT = generalPanelFatigueAlertCheckbox.isSelected();

--- a/src/Client/ConfigWindow.java
+++ b/src/Client/ConfigWindow.java
@@ -429,7 +429,7 @@ public class ConfigWindow {
 			generalPanelXPRightAlignFocusButton = addRadioButton("Display on the right", generalPanel, 20);
 			generalPanelXPRightAlignFocusButton.setToolTipText("The XP bar and XP drops will be shown just left of the Settings menu.");
 			generalPanelXPCenterAlignFocusButton = addRadioButton("Display in the center", generalPanel, 20);
-			generalPanelXPCenterAlignFocusButton.setToolTipText("TThe XP bar and XP drops will be shown at the top-middle of the screen.");
+			generalPanelXPCenterAlignFocusButton.setToolTipText("The XP bar and XP drops will be shown at the top-middle of the screen.");
 			XPAlignButtonGroup.add(generalPanelXPRightAlignFocusButton);
 			XPAlignButtonGroup.add(generalPanelXPCenterAlignFocusButton);
 

--- a/src/Client/Settings.java
+++ b/src/Client/Settings.java
@@ -757,6 +757,7 @@ public class Settings
 	public static boolean LOAD_CHAT_HISTORY = false;
 	public static boolean COMBAT_MENU = false;
 	public static boolean SHOW_XPDROPS = true;
+	public static boolean CENTER_XPDROPS = false;
 	public static boolean SHOW_FATIGUEDROPS = true;
 	public static int FATIGUE_FIGURES = 2;
 	public static boolean FATIGUE_ALERT = true;

--- a/src/Game/XPBar.java
+++ b/src/Game/XPBar.java
@@ -25,6 +25,8 @@ import java.awt.Dimension;
 import java.awt.Graphics2D;
 import java.text.NumberFormat;
 
+import Client.Settings;
+
 public class XPBar
 {
 	public XPBar()
@@ -64,7 +66,12 @@ public class XPBar
 
 		// Draw bar
 
-		xp_bar_x = Renderer.width - 210 - bounds.width; //position to the left of the Settings wrench
+		// Check and set the appropriate display position
+		if (Settings.CENTER_XPDROPS)
+			xp_bar_x = (Renderer.width - bounds.width) / 2 ; // position in the center
+		else
+			xp_bar_x = Renderer.width - 210 - bounds.width; //position to the left of the Settings wrench
+
 		int percent = xp * (bounds.width - 2) / xp_needed;
 		
 		int x = xp_bar_x;


### PR DESCRIPTION
This is similar to how OSBuddy and RS3 display their XP bars (or should I say XP circles?). This PR doesn't change any default settings; it is still set to default to showing the XP bar left of the settings icon. This way it should not affect any users who do not want this new feature, it only adds extra options for those who prefer it centered.