### PR TITLE
Replace IRC with Discord

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,9 +14,9 @@
 
 *I will not accept any game automation features (macroing, etc.)*
 
-## IRC
+## Discord
 
-Join #rscplus on Freenode ([Web Chat](http://webchat.freenode.net/?channels=%23rscplus))
+Join our Discord server ([Invite link](https://discord.gg/92gG87h))
 
 ## Features
 - Game resolution changing (about 80% complete)


### PR DESCRIPTION
Nobody seems to use the IRC channel, and when people try to, any messages they post are useless if nobody is online. I made a Discord server that we can use instead. It could be used to better collaborate with developers as well as provide a voice for users.