### PR TITLE
Searchable bank feature via command and updated help commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,8 @@ Most keybinds are configurable via the Settings GUI
 - Ctrl + n - Toggle NPC info
 - Ctrl + p - Toggle Player info
 - Ctrl + h - Toggle hitboxes for NPC info
+- Ctrl + q - Toggle start on searchable bank mode (uses previously 
+stored keyword on searchable bank)
 - Ctrl + [ - Toggle XP drops
 - Ctrl + ] - Toggle fatigue drops
 - Ctrl + l - Logout
@@ -84,6 +86,10 @@ containing "aWord". Note that withdrawing all of a certain item's type
 will push it to the end of the bank and thus withdrawing all should not 
 be done if your bank is tidy. To exit the search mode, speak to the 
 banker again.
+
+*::togglestartsearchedbank <aWord>* - Toggle between searchable bank 
+mode and normal mode; specifying the parameter updates the search 
+keyword stored.
 
 *::toggleroofs* - Toggle roof hiding
 
@@ -280,6 +286,15 @@ banker again.
   <dt>show_fatiguedrops</dt>
   <dd>Range: <i>true or false</i><br>
   Sets whether fatigue drops appear on screen</dd>
+
+  <dt>start_searched_bank</dt>
+  <dd>Range: <i>true or false</i><br>
+  Sets whether bank should start on search mode</dd>
+
+  <dt>search_bank_word</dt>
+  <dd>Range: <i>Any non-empty string</i><br>
+  Sets the word that will be used when starting bank search 
+mode</dd>
   
   <dt>trade_notifications</dt>
   <dd>Range: <i>true or false</i><br>

--- a/README.md
+++ b/README.md
@@ -79,6 +79,12 @@ Most keybinds are configurable via the Settings GUI
 
 *::sleep* - Sleep, provided you have a sleeping bag in inventory
 
+*::banksearch [aWord]* - Searches current bank state for banked items 
+containing "aWord". Note that withdrawing all of a certain item's type 
+will push it to the end of the bank and thus withdrawing all should not 
+be done if your bank is tidy. To exit the search mode, speak to the 
+banker again.
+
 *::toggleroofs* - Toggle roof hiding
 
 *::togglecolor* - Toggle colored text in terminal

--- a/src/Client/ConfigWindow.java
+++ b/src/Client/ConfigWindow.java
@@ -138,6 +138,8 @@ public class ConfigWindow {
 	private JSlider generalPanelFoVSlider;
 	private JCheckBox generalPanelCustomCursorCheckbox;
 	private JSlider generalPanelViewDistanceSlider;
+	private JCheckBox generalPanelStartSearchedBankCheckbox;
+	private JTextField generalPanelSearchBankWordTextfield;
 	
 	// Overlays tab
 	private JCheckBox overlayPanelStatusDisplayCheckbox;
@@ -566,6 +568,27 @@ public class ConfigWindow {
 		generalPanelViewDistanceSlider.setLabelTable(generalPanelViewDistanceLabelTable);
 		generalPanelViewDistanceSlider.setPaintLabels(true);
 		
+		generalPanelStartSearchedBankCheckbox = addCheckbox("Start with Searched Bank", generalPanel);
+		generalPanelStartSearchedBankCheckbox.setToolTipText("Always start with a searched bank");
+		
+		JPanel searchBankPanel = new JPanel();
+		generalPanel.add(searchBankPanel);
+		searchBankPanel.setLayout(new BoxLayout(searchBankPanel, BoxLayout.X_AXIS));
+		searchBankPanel.setPreferredSize(new Dimension(0, 37));
+		searchBankPanel.setAlignmentX(Component.LEFT_ALIGNMENT);
+		searchBankPanel.setBorder(new EmptyBorder(0, 0, 9, 0));
+		
+		JLabel searchBankPanelLabel = new JLabel("Search term used on bank: ");
+		searchBankPanelLabel.setToolTipText("The search term that will be used on bank start");
+		searchBankPanel.add(searchBankPanelLabel);
+		searchBankPanelLabel.setAlignmentY((float)0.9);
+		
+		generalPanelSearchBankWordTextfield = new JTextField();
+		searchBankPanel.add(generalPanelSearchBankWordTextfield);
+		generalPanelSearchBankWordTextfield.setMinimumSize(new Dimension(100, 28));
+		generalPanelSearchBankWordTextfield.setMaximumSize(new Dimension(Short.MAX_VALUE, 28));
+		generalPanelSearchBankWordTextfield.setAlignmentY((float)0.75);
+		
 		/*
 		 * Overlays tab
 		 */
@@ -805,6 +828,7 @@ public class ConfigWindow {
 		addKeybindSet(keybindPanel, "Toggle inventory full alert", "toggle_inventory_full_alert", KeyModifier.CTRL, KeyEvent.VK_V);
 		addKeybindSet(keybindPanel, "Toggle roof hiding", "toggle_roof_hiding", KeyModifier.CTRL, KeyEvent.VK_R);
 		addKeybindSet(keybindPanel, "Toggle color coded text", "toggle_colorize", KeyModifier.CTRL, KeyEvent.VK_Z);
+		addKeybindSet(keybindPanel, "Toggle start with searched bank", "toggle_start_searched_bank", KeyModifier.CTRL, KeyEvent.VK_Q);
 		
 		addKeybindCategory(keybindPanel, "Overlays");
 		addKeybindSet(keybindPanel, "Toggle HP/prayer/fatigue display", "toggle_hpprayerfatigue_display", KeyModifier.CTRL, KeyEvent.VK_U);
@@ -1092,6 +1116,8 @@ public class ConfigWindow {
 		generalPanelFoVSlider.setValue(Settings.FOV);
 		generalPanelCustomCursorCheckbox.setSelected(Settings.SOFTWARE_CURSOR);
 		generalPanelViewDistanceSlider.setValue(Settings.VIEW_DISTANCE);
+		generalPanelStartSearchedBankCheckbox.setSelected(Settings.START_SEARCHEDBANK);
+		generalPanelSearchBankWordTextfield.setText(Settings.SEARCH_BANK_WORD);
 		
 		// Sets the text associated with the name patch slider.
 		switch (generalPanelNamePatchModeSlider.getValue()) {
@@ -1176,6 +1202,8 @@ public class ConfigWindow {
 		Settings.FOV = generalPanelFoVSlider.getValue();
 		Settings.SOFTWARE_CURSOR = generalPanelCustomCursorCheckbox.isSelected();
 		Settings.VIEW_DISTANCE = generalPanelViewDistanceSlider.getValue();
+		Settings.START_SEARCHEDBANK = generalPanelStartSearchedBankCheckbox.isSelected();
+		Settings.SEARCH_BANK_WORD = generalPanelSearchBankWordTextfield.getText().trim().toLowerCase();
 		
 		// Overlays options
 		Settings.SHOW_STATUSDISPLAY = overlayPanelStatusDisplayCheckbox.isSelected();

--- a/src/Client/Settings.java
+++ b/src/Client/Settings.java
@@ -132,6 +132,10 @@ public class Settings {
 													// details are shown at login welcome screen
 	public static boolean SAVE_LOGININFO = true;
 	
+	// Settings for searchable bank
+	public static boolean START_SEARCHEDBANK = false;
+	public static String SEARCH_BANK_WORD = "";
+	
 	// Miscellaneous settings (No GUI)
 	public static int COMBAT_STYLE = Client.COMBAT_AGGRESSIVE;
 	public static int WORLD = 2;
@@ -200,6 +204,8 @@ public class Settings {
 			FOV = getInt(props, "fov", FOV);
 			SOFTWARE_CURSOR = getBoolean(props, "software_cursor", SOFTWARE_CURSOR);
 			VIEW_DISTANCE = getInt(props, "view_distance", VIEW_DISTANCE);
+			START_SEARCHEDBANK = getBoolean(props, "start_searched_bank", START_SEARCHEDBANK);
+			SEARCH_BANK_WORD = getString(props, "search_bank_word", SEARCH_BANK_WORD);
 			
 			// Overlays options
 			SHOW_STATUSDISPLAY = getBoolean(props, "show_statusdisplay", SHOW_STATUSDISPLAY);
@@ -349,6 +355,8 @@ public class Settings {
 			props.setProperty("fov", Integer.toString(FOV));
 			props.setProperty("software_cursor", Boolean.toString(SOFTWARE_CURSOR));
 			props.setProperty("view_distance", Integer.toString(VIEW_DISTANCE));
+			props.setProperty("start_searched_bank", Boolean.toString(START_SEARCHEDBANK));
+			props.setProperty("search_bank_word", "" + SEARCH_BANK_WORD);
 			
 			// Overlays
 			props.setProperty("show_statusdisplay", Boolean.toString(SHOW_STATUSDISPLAY));
@@ -567,6 +575,26 @@ public class Settings {
 			Client.displayMessage("@cya@Login details will appear next time", Client.CHAT_NONE);
 		else
 			Client.displayMessage("@cya@Login details will not appear next time", Client.CHAT_NONE);
+		save();
+	}
+	
+	public static void toggleStartSearchedBank(String searchWord, boolean replaceSavedWord) {
+		// Settings.SEARCH_BANK_WORD should be trimmed
+		if (Settings.SEARCH_BANK_WORD.trim().equals("") && searchWord.trim().equals("")) {
+			if (Settings.START_SEARCHEDBANK) {
+				START_SEARCHEDBANK = !START_SEARCHEDBANK;
+			}
+		} else {
+			START_SEARCHEDBANK = !START_SEARCHEDBANK;
+			// check if search word should be updated
+			if (replaceSavedWord && !searchWord.trim().equals("") && !searchWord.trim().toLowerCase().equals(Settings.SEARCH_BANK_WORD)) {
+				Settings.SEARCH_BANK_WORD = searchWord.trim().toLowerCase();
+			}
+			if (Settings.START_SEARCHEDBANK)
+				Client.displayMessage("@cya@Your bank will start searched with keyword '" + Settings.SEARCH_BANK_WORD + "' next time", Client.CHAT_NONE);
+			else
+				Client.displayMessage("@cya@Your bank will start as normal next time", Client.CHAT_NONE);
+		}
 		save();
 	}
 	
@@ -836,6 +864,9 @@ public class Settings {
 		case "toggle_xp_drops":
 			Settings.toggleXpDrops();
 			break;
+		case "toggle_start_searched_bank":
+			Settings.toggleStartSearchedBank("", false);
+			break;
 		case "show_config_window":
 			Launcher.getConfigWindow().showConfigWindow();
 			break;
@@ -885,6 +916,8 @@ public class Settings {
 		FOV = 9;
 		SOFTWARE_CURSOR = false;
 		VIEW_DISTANCE = 10000;
+		START_SEARCHEDBANK = false;
+		SEARCH_BANK_WORD = "";
 		Launcher.getConfigWindow().synchronizeGuiValues();
 	}
 	

--- a/src/Client/Settings.java
+++ b/src/Client/Settings.java
@@ -45,7 +45,7 @@ public class Settings {
 	// Internally used variables
 	public static boolean fovUpdateRequired;
 	public static boolean versionCheckRequired = true;
-	public static final double VERSION_NUMBER = 20180513.192907;
+	public static final double VERSION_NUMBER = 20180517.154814;
 	/**
 	 * A time stamp corresponding to the current version of this source code. Used as a sophisticated versioning system.
 	 *

--- a/src/Game/Bank.java
+++ b/src/Game/Bank.java
@@ -186,11 +186,11 @@ public class Bank {
 		bankSearch(sb.toString(), help);
 	}
 	
-	//
 	/**
 	 * Filters out current bank state to match items with given keyword
 	 * 
 	 * @param search The complete clean search query to do the search
+         * @param help display help on command
 	 */
 	public static void bankSearch(String search, boolean help) {
 		if (search.trim().equals("") || help) {
@@ -240,14 +240,10 @@ public class Bank {
 	/**
 	 * Bank search without modifying positions, just lists out banked elements and where they are located
 	 * 
-	 * @param search
-	 * @param bankItems
-	 * @param bankItemsCount
+	 * @param search The complete clean search query to do the search
+	 * @param help display help on command
 	 */
-	public static void query(String search, boolean help) // this is for users who
-																								// want to read the
-																								// readme in game
-	{
+	public static void query(String search, boolean help) {
 		if (search.trim().equals("") || help) {
 			Client.displayMessage("@whi@::querybank is a top-10 based system.", Client.CHAT_QUEST);
 			Client.displayMessage("@whi@Type \"::querybank [aString]\" to search banked items with query string aString", Client.CHAT_QUEST);

--- a/src/Game/Bank.java
+++ b/src/Game/Bank.java
@@ -190,7 +190,7 @@ public class Bank {
 	 * Filters out current bank state to match items with given keyword
 	 * 
 	 * @param search The complete clean search query to do the search
-         * @param help display help on command
+	 * @param help display help on command
 	 */
 	public static void bankSearch(String search, boolean help) {
 		if (search.trim().equals("") || help) {

--- a/src/Game/Bank.java
+++ b/src/Game/Bank.java
@@ -1,0 +1,283 @@
+/**
+ *	rscplus
+ *
+ *	This file is part of rscplus.
+ *
+ *	rscplus is free software: you can redistribute it and/or modify
+ *	it under the terms of the GNU General Public License as published by
+ *	the Free Software Foundation, either version 3 of the License, or
+ *	(at your option) any later version.
+ *
+ *	rscplus is distributed in the hope that it will be useful,
+ *	but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *	GNU General Public License for more details.
+ *
+ *	You should have received a copy of the GNU General Public License
+ *	along with rscplus.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ *	Authors: see <https://github.com/OrN/rscplus>
+ */
+
+package Game;
+
+public class Bank {
+	
+	/**
+	 * This method resets the query flag and "exclude inventory-only item" flag, it sets up first time visiting bank
+	 * flag
+	 */
+	public static void openedBankInterfaceHook() {
+		Client.new_bank_items[253] = 0;
+		Client.new_bank_items[254] = 1;
+		Client.new_bank_items[255] = 0;
+	}
+	
+	/**
+	 * This method removes the inventory only items shown in bank, if user is in "searchable bank" mode
+	 * otherwise it enters weird glitch mode as user does operations of withdraw/deposit on items
+	 */
+	public static void finalBankItemsHook() {
+		if (Client.new_bank_items[253] != 0) {
+			// remove inventory only items shown at bank, if its in searchable bank mode
+			// to remove some glitches
+			for (int i = Client.new_count_items_bank; i < 255; i++) {
+				Client.bank_items[i] = 0;
+				Client.bank_items_count[i] = 0;
+				Client.new_bank_items[i] = 0;
+				Client.new_bank_items_count[i] = 0;
+			}
+			Client.bank_items[255] = 0;
+			Client.bank_items_count[255] = 0;
+			Client.count_items_bank = Client.new_count_items_bank;
+		}
+	}
+	
+	/**
+	 * This method hooks update bank
+	 * new_bank_items = bank_items
+	 * flags: new_bank_items[253] -> indicates if 'inventory only' items appearing at bank interface should be removed
+	 * new_bank_items[254] -> indicates user first time opened the interface
+	 * new_bank_items[255] -> indicates user is in "searchable bank" mode
+	 */
+	public static void updateBankItemsHook() {
+		if (Client.new_bank_items[254] == 1) {
+			// first time bank interface, unset the flag
+			Client.new_bank_items[254] = 0;
+		} else {
+			if (Client.new_bank_items[255] == 1) {
+				// this flag needs to be unset itself because it can cause noise when detecting changed item
+				Client.new_bank_items[255] = 0;
+				// only shown items saved in bank = queried bank
+				boolean isQueried = true;
+				int array_len = 256;
+				for (int l = Client.new_count_items_bank; l < array_len; l++) {
+					if (Client.bank_items[l] != 0 && Client.bank_items_count[l] == 0) {
+						isQueried = false;
+						break;
+					}
+				}
+				if (isQueried) {
+					try {
+						// fix updating bank interface from deposit/withdraw after querying bank
+						
+						// need to detect changed item
+						int posChanged, itemIdChanged, itemCountChanged;
+						itemIdChanged = itemCountChanged = posChanged = -1;
+						
+						for (int i = 0; i < Client.new_count_items_bank; i++) {
+							if (Client.new_bank_items[i] != Client.bank_items[i] && !(Client.new_bank_items[i] == 0 && Client.new_bank_items_count[i] == 0)) {
+								if (Client.new_bank_items[i] == Client.bank_items[i + 1] && Client.new_bank_items_count[i] == Client.bank_items_count[i + 1])
+									continue;
+								
+								itemIdChanged = Client.new_bank_items[i];
+								itemCountChanged = Client.new_bank_items_count[i];
+								posChanged = i;
+								
+								break;
+							}
+						}
+						if (posChanged != -1) {
+							// update changed item onto tempBankItems
+							for (int i = 0; i < Client.new_count_items_bank; i++) {
+								// did not withdraw all, can also be deposit some
+								if (Client.bank_items[i] == itemIdChanged && Client.bank_items_count[i] != 0 && itemCountChanged > 0) {
+									Client.new_bank_items_count[i] = itemCountChanged;
+									if (Client.bank_items_count[posChanged] != 0 && Client.bank_items[posChanged] != 0) {
+										Client.new_bank_items[posChanged] = Client.bank_items[posChanged];
+										Client.new_bank_items_count[posChanged] = Client.bank_items_count[posChanged];
+									} else {
+										Client.new_bank_items[posChanged] = Client.bank_items[posChanged];
+										Client.new_bank_items_count[posChanged] = Client.bank_items_count[posChanged];
+									}
+									break;
+								}
+							}
+							
+							// cleanup (might be redundant) but better safe
+							int[] tmpNewItems = new int[array_len];
+							int[] tmpNewItemsCount = new int[array_len];
+							int n = 0;
+							for (int i = 0; i < array_len; i++) {
+								if (!(Client.new_bank_items[i] == 0 && Client.new_bank_items_count[i] == 0)) {
+									tmpNewItems[n] = Client.new_bank_items[n];
+									tmpNewItemsCount[n] = Client.new_bank_items_count[n];
+									n++;
+								}
+							}
+							
+							Client.new_bank_items = tmpNewItems;
+							Client.new_bank_items_count = tmpNewItemsCount;
+							Client.new_count_items_bank = n;
+							Client.count_items_bank = n;
+						} else {
+							// Could not detect which position changed since new_bank_items are exactly the same
+							// as bank_items -> check inventory items until match.
+							// if not ??
+							
+							int i, j;
+							i = j = 0;
+							for (i = 0; i < Client.inventory_count; i++) {
+								for (j = 0; j < Client.new_count_items_bank; j++) {
+									if (Client.inventory_items[i] == Client.new_bank_items[j]) {
+										posChanged = j;
+										break;
+									}
+								}
+							}
+							if (posChanged != -1) {
+								// move elements up from index to fix glitch
+								for (i = posChanged; i < Client.new_count_items_bank; i++) {
+									Client.new_bank_items[i] = Client.new_bank_items[i + 1];
+									Client.new_bank_items_count[i] = Client.new_bank_items_count[i + 1];
+								}
+								Client.new_bank_items[i] = Client.new_bank_items[i - 1];
+								Client.new_bank_items_count[i] = Client.new_bank_items_count[i - 1];
+							}
+						}
+						
+						// in searchable bank, setting this flag also to indicate to remove inventory only items
+						Client.new_bank_items[253] = 1;
+					} catch (Exception e) {
+						e.printStackTrace();
+					}
+				}
+				// all operations finished, set searchable bank mode back on
+				Client.new_bank_items[255] = 1;
+			}
+		}
+	}
+	
+	/**
+	 * Entry point, since the same command array is used from Client.processClientCommand, index starts with 1
+	 * (validated before)
+	 * 
+	 * @param cmdArray the command array used on Client.processClientCommand
+	 */
+	public static void search(String[] cmdArray, boolean help) {
+		StringBuilder sb = new StringBuilder();
+		for (int i = 1; i < cmdArray.length; i++) {
+			if (cmdArray[i].trim().equals(""))
+				continue;
+			sb.append(cmdArray[i].trim());
+			if (i < cmdArray.length - 1)
+				sb.append(" ");
+		}
+		bankSearch(sb.toString(), help);
+	}
+	
+	//
+	/**
+	 * Filters out current bank state to match items with given keyword
+	 * 
+	 * @param search The complete clean search query to do the search
+	 */
+	public static void bankSearch(String search, boolean help) {
+		if (search.trim().equals("") || help) {
+			Client.displayMessage("@whi@::banksearch is a searchable bank mode", Client.CHAT_QUEST);
+			Client.displayMessage("@whi@Type \"::banksearch [aString]\" to search banked items with query string aString", Client.CHAT_QUEST);
+			Client.displayMessage("@whi@Bank is updated to show only matched items.", Client.CHAT_QUEST);
+			Client.displayMessage("@whi@To exit the mode, speak to the banker again.", Client.CHAT_QUEST);
+		} else {
+			// not in bank, display notice
+			if (!Client.show_bank) {
+				Client.displayMessage("@whi@::banksearch is only available when bank interface is open", Client.CHAT_QUEST);
+			} else {
+				int[] tmpBankItems = Client.bank_items.clone();
+				int[] tmpBankItemsCount = Client.bank_items_count.clone();
+				int[] tmpNewBankItems = Client.new_bank_items.clone();
+				int[] tmpNewBankItemsCount = Client.new_bank_items_count.clone();
+				// clear everything to avoid error
+				for (int i = 0; i < Client.bank_items.length; i++) {
+					Client.bank_items[i] = 0;
+					Client.bank_items_count[i] = 0;
+					Client.new_bank_items[i] = 0;
+					Client.new_bank_items_count[i] = 0;
+					Client.count_items_bank = 0;
+					Client.new_count_items_bank = 0;
+				}
+				int n = 0;
+				// place only those items matching the criteria
+				for (int i = 0; i < tmpNewBankItems.length; i++) {
+					if (tmpBankItemsCount[i] == 0)
+						break;
+					if (Item.item_name[tmpBankItems[i]].toLowerCase().contains(search)) {
+						Client.bank_items[n] = tmpBankItems[i];
+						Client.bank_items_count[n] = tmpBankItemsCount[i];
+						Client.new_bank_items[n] = tmpNewBankItems[i];
+						Client.new_bank_items_count[n] = tmpNewBankItemsCount[i];
+						n++;
+					}
+				}
+				
+				Client.count_items_bank = n;
+				Client.new_count_items_bank = n;
+				Client.new_bank_items[255] = 1;
+			}
+		}
+	}
+	
+	/**
+	 * Bank search without modifying positions, just lists out banked elements and where they are located
+	 * 
+	 * @param search
+	 * @param bankItems
+	 * @param bankItemsCount
+	 */
+	public static void query(String search, boolean help) // this is for users who
+																								// want to read the
+																								// readme in game
+	{
+		if (search.trim().equals("") || help) {
+			Client.displayMessage("@whi@::querybank is a top-10 based system.", Client.CHAT_QUEST);
+			Client.displayMessage("@whi@Type \"::querybank [aString]\" to search banked items with query string aString", Client.CHAT_QUEST);
+			Client.displayMessage("@whi@You can go back in 'Quest history' to read pages that have disappeared.", Client.CHAT_QUEST);
+		} else {
+			int page, row, col, tmp;
+			Client.displayMessage("@whi@" + "Queried bank with '" + search + "'", Client.CHAT_QUEST);
+			for (int i = 0; i < Client.bank_items.length; i++) {
+				if (Client.bank_items_count[i] == 0)
+					break;
+				if (Item.item_name[Client.bank_items[i]].toLowerCase().contains(search)) {
+					page = i / 48;
+					tmp = i - 48 * page;
+					page++;
+					row = (tmp / 8) + 1;
+					col = (tmp % 8) + 1;
+					Client.displayMessage(
+							"@whi@" + " " + Item.item_name[Client.bank_items[i]] + " (" + pluralize(Client.bank_items_count[i]) + ")" + " at Page " + page + ", Row " + row
+									+ ", Column " + col,
+							Client.CHAT_QUEST);
+				}
+			}
+		}
+	}
+	
+	public static String pluralize(int count) {
+		if (count == 1)
+			return count + " pc";
+		else
+			return count + " pcs";
+	}
+	
+}

--- a/src/Game/Client.java
+++ b/src/Game/Client.java
@@ -154,6 +154,21 @@ public class Client {
 	public static Object writeBuffer;
 	public static Object menuCommon;
 	
+	// bank items and their count for each type, new bank items are first to get updated and indicate bank
+	// excluding inventory types and bank items do include them (in regular mode), as bank operations are messy
+	// they get excluded also in searchable bank
+	public static int[] bank_items_count;
+	public static int[] bank_items;
+	public static int[] new_bank_items_count;
+	public static int[] new_bank_items;
+	
+	// these two variables, they indicate distinct bank items count
+	public static int new_count_items_bank;
+	public static int count_items_bank;
+	
+	public static int selectedItem;
+	public static int selectedItemSlot;
+	
 	/**
 	 * An array of Strings that stores text used in the client
 	 */
@@ -426,6 +441,14 @@ public class Client {
 				break;
 			case "togglelogindetails":
 				Settings.toggleShowLoginDetails();
+				break;
+			case "banksearch":
+				// enters searchable bank mode, to return normal mode player has to speak to the banker again
+				if (commandArray.length > 1) {
+					Bank.search(commandArray, false);
+				} else {
+					Bank.search(commandArray, true);
+				}
 				break;
 			case "sleep":
 				Client.sleep();

--- a/src/Game/Client.java
+++ b/src/Game/Client.java
@@ -442,6 +442,22 @@ public class Client {
 			case "togglelogindetails":
 				Settings.toggleShowLoginDetails();
 				break;
+			case "togglestartsearchedbank":
+				if (commandArray.length > 1) {
+					StringBuilder sb = new StringBuilder();
+					for (int i = 1; i < commandArray.length; i++) {
+						if (commandArray[i].trim().equals(""))
+							continue;
+						sb.append(commandArray[i].trim().toLowerCase());
+						if (i < commandArray.length - 1)
+							sb.append(" ");
+					}
+					Settings.toggleStartSearchedBank(sb.toString(), true);
+				} else {
+					Settings.toggleStartSearchedBank("", false);
+				}
+				
+				break;
 			case "banksearch":
 				// enters searchable bank mode, to return normal mode player has to speak to the banker again
 				if (commandArray.length > 1) {

--- a/src/Game/Help.java
+++ b/src/Game/Help.java
@@ -99,6 +99,7 @@ public class Help {
 				switch (page) {
 				case 1:
 					Client.displayMessage("@whi@Page 1 of 1", Client.CHAT_QUEST);
+					Client.displayMessage("@whi@::banksearch [aWord] - Searches the bank for items containing aWord", Client.CHAT_QUEST);
 					Client.displayMessage("@whi@::sleep - Sleep, provided you have a sleeping bag", Client.CHAT_QUEST);
 					Client.displayMessage("@whi@::logout - Logout", Client.CHAT_QUEST);
 					Client.displayMessage("@whi@::screenshot - Take screenshot (Saved in the screenshots directory)", Client.CHAT_QUEST);

--- a/src/Game/Help.java
+++ b/src/Game/Help.java
@@ -68,6 +68,8 @@ public class Help {
 				case 3:
 					Client.displayMessage("@whi@Page 3 of 3", Client.CHAT_QUEST);
 					Client.displayMessage("@whi@::togglexpdrops - Toggle XP drops", Client.CHAT_QUEST);
+					Client.displayMessage("@whi@::togglestartsearchedbank <aWord> - Toggle between starting bank on search mode", Client.CHAT_QUEST);
+					Client.displayMessage("@whi@ optionally specify the bank search word", Client.CHAT_QUEST);
 					break;
 				default:
 					Client.displayMessage("@whi@page does not exist", Client.CHAT_QUEST);

--- a/src/Game/Reflection.java
+++ b/src/Game/Reflection.java
@@ -233,5 +233,4 @@ public class Reflection {
 			e.printStackTrace();
 		}
 	}
-	
 }


### PR DESCRIPTION
Idea from Pockets, searchable command can be ported graphically in a future update (without much trouble in my opinion). I wanted to have a reset search option without having to speak to the banker but when I tried the Client's class variable values were lost after hooking so I dropped the option.