### PR TITLE
RSC content loader cache

### DIFF
--- a/src/Client/CacheDownload.java
+++ b/src/Client/CacheDownload.java
@@ -1,0 +1,85 @@
+/**
+ *	rscplus
+ *
+ *	This file is part of rscplus.
+ *
+ *	rscplus is free software: you can redistribute it and/or modify
+ *	it under the terms of the GNU General Public License as published by
+ *	the Free Software Foundation, either version 3 of the License, or
+ *	(at your option) any later version.
+ *
+ *	rscplus is distributed in the hope that it will be useful,
+ *	but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *	GNU General Public License for more details.
+ *
+ *	You should have received a copy of the GNU General Public License
+ *	along with rscplus.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ *	Authors: see <https://github.com/OrN/rscplus>
+ */
+
+package Client;
+
+import java.io.FileOutputStream;
+import java.io.InputStream;
+import java.net.URL;
+import java.nio.ByteBuffer;
+import java.nio.channels.FileChannel;
+
+public class CacheDownload {
+	private String m_serverAddress;
+	private String m_file;
+	private ByteBuffer m_data;
+	
+	CacheDownload(String file) {
+		// Randomize the world we download from to reduce load among users/downloads
+		int world = 1 + (int)(4.99 * Math.random());
+		m_serverAddress = "classic" + world + ".runescape.com";
+		
+		m_file = file;
+		m_data = null;
+	}
+	
+	public ByteBuffer getDataBuffer() {
+		return m_data;
+	}
+	
+	public boolean dump(String fname) {
+		try {
+			FileOutputStream stream = new FileOutputStream(fname);
+			FileChannel out = stream.getChannel();
+			out.write(m_data);
+			out.close();
+			stream.close();
+		}
+		catch (Exception e) {
+		}
+		return true;
+	}
+	
+	public boolean fetch() {
+		try {
+			URL url = new URL("http://" + m_serverAddress + m_file);
+			int contentLength = url.openConnection().getContentLength();
+			InputStream input = url.openStream();
+			
+			m_data = ByteBuffer.allocate(contentLength);
+			int readSize = 0;
+			int offset = 0;
+			while ((readSize = input.read(m_data.array(), offset, m_data.capacity() - offset)) >= 0) {
+				offset += readSize;
+			}
+			input.close();
+			
+			if (contentLength != offset) {
+				return false;
+			}
+			
+			return true;
+		} catch (Exception e) {
+			e.printStackTrace();
+		}
+		return false;
+	}
+}

--- a/src/Client/CacheDownload.java
+++ b/src/Client/CacheDownload.java
@@ -26,11 +26,13 @@ import java.io.InputStream;
 import java.net.URL;
 import java.nio.ByteBuffer;
 import java.nio.channels.FileChannel;
+import java.util.zip.CRC32;
 
 public class CacheDownload {
 	private String m_serverAddress;
 	private String m_file;
 	private ByteBuffer m_data;
+	private int m_crc;
 	
 	CacheDownload(String file) {
 		// Randomize the world we download from to reduce load among users/downloads
@@ -39,10 +41,15 @@ public class CacheDownload {
 		
 		m_file = file;
 		m_data = null;
+		m_crc = 0;
 	}
 	
 	public ByteBuffer getDataBuffer() {
 		return m_data;
+	}
+	
+	public int getCRC() {
+		return m_crc;
 	}
 	
 	public boolean dump(String fname) {
@@ -75,6 +82,10 @@ public class CacheDownload {
 			if (contentLength != offset) {
 				return false;
 			}
+			
+			CRC32 crc = new CRC32();
+			crc.update(m_data.array());
+			m_crc = (int)crc.getValue();
 			
 			return true;
 		} catch (Exception e) {

--- a/src/Client/CacheDownload.java
+++ b/src/Client/CacheDownload.java
@@ -24,6 +24,7 @@ package Client;
 import java.io.FileOutputStream;
 import java.io.InputStream;
 import java.net.URL;
+import java.net.URLConnection;
 import java.nio.ByteBuffer;
 import java.nio.channels.FileChannel;
 import java.util.zip.CRC32;
@@ -69,7 +70,10 @@ public class CacheDownload {
 	public boolean fetch() {
 		try {
 			URL url = new URL("http://" + m_serverAddress + m_file);
-			int contentLength = url.openConnection().getContentLength();
+			URLConnection connection = url.openConnection();
+			connection.setConnectTimeout(5000);
+			connection.setReadTimeout(5000);
+			int contentLength = connection.getContentLength();
 			InputStream input = url.openStream();
 			
 			m_data = ByteBuffer.allocate(contentLength);

--- a/src/Client/CacheDownload.java
+++ b/src/Client/CacheDownload.java
@@ -61,6 +61,7 @@ public class CacheDownload {
 			stream.close();
 		}
 		catch (Exception e) {
+			return false;
 		}
 		return true;
 	}

--- a/src/Client/JClassPatcher.java
+++ b/src/Client/JClassPatcher.java
@@ -79,6 +79,8 @@ public class JClassPatcher {
 			patchClient(node);
 		else if (node.name.equals("f"))
 			patchRandom(node);
+		else if (node.name.equals("da"))
+			patchGameApplet(node);
 		
 		// Patch applied to all classes
 		patchGeneric(node);
@@ -912,6 +914,25 @@ public class JClassPatcher {
 							methodNode.instructions.insert(insnNode, new TypeInsnNode(Opcodes.NEW, "java/util/Random"));
 						}
 					}
+				}
+			}
+		}
+	}
+	
+	private void patchGameApplet(ClassNode node) {
+		Logger.Info("Patching GameApplet (" + node.name + ".class)");
+		
+		Iterator<MethodNode> methodNodeList = node.methods.iterator();
+		while (methodNodeList.hasNext()) {
+			MethodNode methodNode = methodNodeList.next();
+			
+			if (methodNode.name.equals("a")) {
+				if (methodNode.desc.equals("(Ljava/net/URL;ZZ)[B")) {
+					Iterator<AbstractInsnNode> insnNodeList = methodNode.instructions.iterator();
+					AbstractInsnNode insnNode = insnNodeList.next();
+					methodNode.instructions.insertBefore(insnNode, new VarInsnNode(Opcodes.ALOAD, 0));
+					methodNode.instructions.insertBefore(insnNode, new MethodInsnNode(Opcodes.INVOKESTATIC, "Game/GameApplet", "cacheURLHook", "(Ljava/net/URL;)Ljava/net/URL;"));
+					methodNode.instructions.insertBefore(insnNode, new VarInsnNode(Opcodes.ASTORE, 0));
 				}
 			}
 		}

--- a/src/Client/Launcher.java
+++ b/src/Client/Launcher.java
@@ -111,7 +111,9 @@ public class Launcher extends JFrame implements Runnable {
 		}
 		
 		setStatus("Updating game cache...");
-		updateCache();
+		if (!updateCache()) {
+			error("Unable to update game cache");
+		}
 		
 		setStatus("Launching game...");
 		Game game = Game.getInstance();
@@ -137,6 +139,7 @@ public class Launcher extends JFrame implements Runnable {
 		setStatus("Error: " + text);
 		try {
 			Thread.sleep(5000);
+			System.exit(0);
 		} catch (Exception e) {
 		}
 	}
@@ -155,7 +158,8 @@ public class Launcher extends JFrame implements Runnable {
 		});
 	}
 	
-	public void updateCache() {
+	public boolean updateCache() {
+		boolean success = true;
 		String contentcrcs_fname = "/contentcrcs" + Long.toHexString(System.currentTimeMillis());
 		CacheDownload download = new CacheDownload(contentcrcs_fname);
 		if (download.fetch()) {
@@ -174,7 +178,7 @@ public class Launcher extends JFrame implements Runnable {
 						setStatus("Cache file '" + idx_fname + "' is up-to-date");
 						downloadContent = false;
 					} else {
-						Logger.Error("Cache CRC mismatch (" + idx_crc + " != " + file_crc + "), redownloading file '" + idx_fname + "'");
+						Logger.Info("Cache CRC mismatch (" + idx_crc + " != " + file_crc + "), redownloading file '" + idx_fname + "'");
 					}
 				}
 				
@@ -186,12 +190,15 @@ public class Launcher extends JFrame implements Runnable {
 						download.dump(Settings.Dir.CACHE + idx_fname);
 					} else {
 						Logger.Error("Failed to download cache file '" + idx_fname + "'");
+						success = false;
 					}
 				}
 			}
 		} else {
 			Logger.Error("Failed to retrieve contentcrcs to update cache!");
+			success = false;
 		}
+		return success;
 	}
 	
 	/**

--- a/src/Client/Launcher.java
+++ b/src/Client/Launcher.java
@@ -187,7 +187,12 @@ public class Launcher extends JFrame implements Runnable {
 					setStatus("Updating cache file '" + idx_fname + "'...");
 					download = new CacheDownload(idx_fname);
 					if (download.fetch()) {
-						download.dump(Settings.Dir.CACHE + idx_fname);
+						if (download.getCRC() == idx_crc) {
+							download.dump(Settings.Dir.CACHE + idx_fname);
+						} else {
+							Logger.Error("CRC mismatch while downloading cache file '" + idx_fname + "'");
+							success = false;
+						}
 					} else {
 						Logger.Error("Failed to download cache file '" + idx_fname + "'");
 						success = false;

--- a/src/Client/Launcher.java
+++ b/src/Client/Launcher.java
@@ -163,7 +163,10 @@ public class Launcher extends JFrame implements Runnable {
 		String contentcrcs_fname = "/contentcrcs" + Long.toHexString(System.currentTimeMillis());
 		CacheDownload download = new CacheDownload(contentcrcs_fname);
 		if (download.fetch()) {
-			download.dump(Settings.Dir.CACHE + "/contentcrcs");
+			if (!download.dump(Settings.Dir.CACHE + "/contentcrcs")) {
+				Logger.Error("Unable to write contentcrcs cache file to path");
+				success = false;
+			}
 			ByteBuffer data = download.getDataBuffer();
 			int cacheCount = (data.capacity() - 8) / 4;
 			for (int idx = 0; idx < cacheCount; idx++) {
@@ -188,7 +191,10 @@ public class Launcher extends JFrame implements Runnable {
 					download = new CacheDownload(idx_fname);
 					if (download.fetch()) {
 						if (download.getCRC() == idx_crc) {
-							download.dump(Settings.Dir.CACHE + idx_fname);
+							if (!download.dump(Settings.Dir.CACHE + idx_fname)) {
+								Logger.Error("Unable to write cache file '" + idx_fname + "' to path");
+								success = false;
+							}
 						} else {
 							Logger.Error("CRC mismatch while downloading cache file '" + idx_fname + "'");
 							success = false;

--- a/src/Client/Launcher.java
+++ b/src/Client/Launcher.java
@@ -112,7 +112,7 @@ public class Launcher extends JFrame implements Runnable {
 		
 		setStatus("Updating game cache...");
 		if (!updateCache()) {
-			error("Unable to update game cache");
+			Logger.Info("Some of the cache has failed to download, but we're going to try and continue anyway");
 		}
 		
 		setStatus("Launching game...");
@@ -206,8 +206,7 @@ public class Launcher extends JFrame implements Runnable {
 				}
 			}
 		} else {
-			Logger.Error("Failed to retrieve contentcrcs to update cache!");
-			success = false;
+			Logger.Error("Failed to retrieve contentcrcs, attempting run anyway!");
 		}
 		return success;
 	}

--- a/src/Client/Settings.java
+++ b/src/Client/Settings.java
@@ -32,8 +32,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Properties;
 import Client.KeybindSet.KeyModifier;
-import Client.NotificationsHandler;
-import Client.Util;
 import Game.Camera;
 import Game.Client;
 import Game.Game;
@@ -48,7 +46,7 @@ public class Settings {
 	// Internally used variables
 	public static boolean fovUpdateRequired;
 	public static boolean versionCheckRequired = true;
-	public static final double VERSION_NUMBER = 20180517.154814;
+	public static final double VERSION_NUMBER = 20180520.124505;
 	/**
 	 * A time stamp corresponding to the current version of this source code. Used as a sophisticated versioning system.
 	 *

--- a/src/Client/Util.java
+++ b/src/Client/Util.java
@@ -28,7 +28,9 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.net.URL;
 import java.net.URLConnection;
+import java.nio.file.Files;
 import java.util.ArrayList;
+import java.util.zip.CRC32;
 
 /**
  * A miscellaneous utility class
@@ -47,6 +49,24 @@ public class Util {
 	
 	private Util() {
 		// Empty private constructor to prevent instantiation.
+	}
+	
+	/**
+	 * Gets the CRC32 of a given file name.
+	 * 
+	 * @param fname Path to the file
+	 * @return CRC32 of the file data
+	 */
+	public static long fileGetCRC32(String fname) {
+		try {
+			byte[] data = Files.readAllBytes(new File(fname).toPath());
+			CRC32 crc = new CRC32();
+			crc.update(data);
+			return crc.getValue();
+		} catch (Exception e) {
+		}
+		
+		return -1;
 	}
 	
 	/**

--- a/src/Game/Client.java
+++ b/src/Game/Client.java
@@ -28,7 +28,6 @@ import java.io.BufferedWriter;
 import java.io.File;
 import java.io.FileWriter;
 import java.io.InputStreamReader;
-import java.lang.reflect.InvocationTargetException;
 import java.net.URL;
 import java.net.URLConnection;
 import java.util.ArrayList;
@@ -149,6 +148,9 @@ public class Client {
 	public static int planeHeight = -1;
 	public static int planeIndex = -1;
 	public static boolean loadingArea = false;
+	
+	public static boolean sleepCmdSent = false;
+	public static int sleepBagIdx = -1;
 	
 	public static Object clientStream;
 	public static Object writeBuffer;
@@ -654,26 +656,27 @@ public class Client {
 	}
 	
 	public static void sleep() {
-		int sleepingBagIdx = -1;
-		// inventory_items contains ids of items
-		for (int n = 0; n < max_inventory; n++) {
-			// id of sleeping bag
-			if (inventory_items[n] == 1263) {
-				sleepingBagIdx = n;
-				break;
+		if (Reflection.itemClick == null)
+			return;
+		
+		try {
+			int idx = -1;
+			// inventory_items contains ids of items
+			for (int n = 0; n < max_inventory; n++) {
+				// id of sleeping bag
+				if (inventory_items[n] == 1263) {
+					idx = n;
+					break;
+				}
 			}
-		}
-		if (sleepingBagIdx != -1 && !Client.isInterfaceOpen() && !Client.isInCombat()) {
-			// method to sleep here
-			try {
-				if (Client.writeBuffer == null)
-					Client.writeBuffer = Reflection.bufferField.get(Client.clientStream);
-				Reflection.newPacket.invoke(Client.clientStream, 90, 0);
-				Reflection.putShort.invoke(Client.writeBuffer, 393, sleepingBagIdx);
-				Reflection.sendPacket.invoke(Client.clientStream, 21294);
-			} catch (IllegalArgumentException | IllegalAccessException | InvocationTargetException e) {
-				// TODO Auto-generated catch block
+			if (idx != -1 && !Client.isInterfaceOpen() && !Client.isInCombat()) {
+				// method to sleep here
+				sleepCmdSent = true;
+				sleepBagIdx = idx;
+				Reflection.itemClick.invoke(Client.instance, false, 0);
 			}
+		} catch (Exception e) {
+			
 		}
 	}
 	

--- a/src/Game/GameApplet.java
+++ b/src/Game/GameApplet.java
@@ -1,0 +1,39 @@
+/**
+ *	rscplus
+ *
+ *	This file is part of rscplus.
+ *
+ *	rscplus is free software: you can redistribute it and/or modify
+ *	it under the terms of the GNU General Public License as published by
+ *	the Free Software Foundation, either version 3 of the License, or
+ *	(at your option) any later version.
+ *
+ *	rscplus is distributed in the hope that it will be useful,
+ *	but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *	GNU General Public License for more details.
+ *
+ *	You should have received a copy of the GNU General Public License
+ *	along with rscplus.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ *	Authors: see <https://github.com/OrN/rscplus>
+ */
+
+package Game;
+
+import java.net.URL;
+import Client.Settings;
+
+public class GameApplet {
+	public static URL cacheURLHook(URL url) {
+		String file = url.getFile();
+		if (file.startsWith("/contentcrcs")) {
+			file = "/contentcrcs";
+		}
+		try {
+			return new URL("file://" + Settings.Dir.CACHE + file);
+		} catch (Exception e) {
+			return null;
+		}
+	}
+}

--- a/src/Game/GameApplet.java
+++ b/src/Game/GameApplet.java
@@ -38,7 +38,7 @@ public class GameApplet {
 			try {
 				return new URL(cache_file.toURI().toString());
 			} catch (Exception e) {
-				return null;
+				return url;
 			}
 		} else {
 			// File doesn't exist in the cache, use the original method

--- a/src/Game/GameApplet.java
+++ b/src/Game/GameApplet.java
@@ -21,6 +21,7 @@
 
 package Game;
 
+import java.io.File;
 import java.net.URL;
 import Client.Settings;
 
@@ -30,10 +31,18 @@ public class GameApplet {
 		if (file.startsWith("/contentcrcs")) {
 			file = "/contentcrcs";
 		}
-		try {
-			return new URL("file://" + Settings.Dir.CACHE + file);
-		} catch (Exception e) {
-			return null;
+		
+		File cache_file = new File(Settings.Dir.CACHE + file);
+		
+		if (cache_file.exists()) {
+			try {
+				return new URL(cache_file.toURI().toString());
+			} catch (Exception e) {
+				return null;
+			}
+		} else {
+			// File doesn't exist in the cache, use the original method
+			return url;
 		}
 	}
 }

--- a/src/Game/Reflection.java
+++ b/src/Game/Reflection.java
@@ -50,6 +50,7 @@ public class Reflection {
 	public static Method setGameBounds = null;
 	public static Method setLoginText = null;
 	public static Method logout = null;
+	public static Method itemClick = null;
 	
 	public static Method newPacket = null;
 	public static Method putShort = null;
@@ -62,6 +63,7 @@ public class Reflection {
 	private static final String SETGAMEBOUNDS = "final void ua.a(int,int,int,int,byte)";
 	private static final String SETLOGINTEXT = "private final void client.b(byte,java.lang.String,java.lang.String)";
 	private static final String LOGOUT = "private final void client.B(int)";
+	private static final String ITEMCLICK = "private final void client.b(boolean,int)";
 	
 	private static final String NEWPACKET = "final void b.b(int,int)";
 	private static final String PUTSHORT = "final void tb.e(int,int)";
@@ -86,6 +88,9 @@ public class Reflection {
 				} else if (method.toGenericString().equals(LOGOUT)) {
 					logout = method;
 					Logger.Info("Found logout");
+				} else if (method.toGenericString().equals(ITEMCLICK)) {
+					itemClick = method;
+					Logger.Info("Found itemClick");
 				}
 			}
 			
@@ -220,6 +225,8 @@ public class Reflection {
 				setLoginText.setAccessible(true);
 			if (logout != null)
 				logout.setAccessible(true);
+			if (itemClick != null)
+				itemClick.setAccessible(true);
 			if (newPacket != null)
 				newPacket.setAccessible(true);
 			if (putShort != null)


### PR DESCRIPTION
Improves load times drastically after the first run, which is pretty slow (about as slow as before).
@lmsv-mx123 found the grabFile hook method, I just adapted it.

We also handle cache updating in our launcher now, and file grabbing is offloaded onto random world servers (probably will be more efficient, especially if we ever thread this), we only grab the content from the server once now though.