### PR TITLE
Fix in hits display, adding to npc objs

### DIFF
--- a/src/Client/Settings.java
+++ b/src/Client/Settings.java
@@ -46,7 +46,7 @@ public class Settings {
 	// Internally used variables
 	public static boolean fovUpdateRequired;
 	public static boolean versionCheckRequired = true;
-	public static final double VERSION_NUMBER = 20180522.020142;
+	public static final double VERSION_NUMBER = 20180522.034227;
 	/**
 	 * A time stamp corresponding to the current version of this source code. Used as a sophisticated versioning system.
 	 *

--- a/src/Game/Client.java
+++ b/src/Game/Client.java
@@ -152,9 +152,6 @@ public class Client {
 	public static boolean sleepCmdSent = false;
 	public static int sleepBagIdx = -1;
 	
-	public static int opponentCurrHealth = -1;
-	public static int opponentMaxHealth = -1;
-	
 	public static Object clientStream;
 	public static Object writeBuffer;
 	public static Object menuCommon;
@@ -658,6 +655,9 @@ public class Client {
 		}
 	}
 	
+	/**
+	 * Send over the instruction of sleep, if player has sleeping bag with them
+	 */
 	public static void sleep() {
 		if (Reflection.itemClick == null)
 			return;
@@ -751,12 +751,20 @@ public class Client {
 		}
 	}
 	
-	// combat
-	public static void inCombatHook(int damageTaken, int currentHealth, int maxHealth) {
+	// combat packet received (testing only, the info is taken on function that draws hits)
+	public static void inCombatHook(int damageTaken, int currentHealth, int maxHealth, int index, int hooknum, Object obj) {
 		// discard if info seems to be for local player
-		if (Client.current_level[Client.SKILL_HP] != currentHealth && Client.base_level[Client.SKILL_HP] != maxHealth) {
-			Client.opponentCurrHealth = currentHealth;
-			Client.opponentMaxHealth = maxHealth;
+		int n1, n2;
+		String name;
+		// object was found
+		if (obj != null) {
+			try {
+				n1 = Reflection.attackingPlayerIdx.getInt(obj);
+				n2 = Reflection.attackingNpcIdx.getInt(obj);
+				name = (String)Reflection.characterDisplayName.get(obj);
+			} catch (IllegalArgumentException | IllegalAccessException e) {
+				// TODO Auto-generated catch block
+			}
 		}
 	}
 	
@@ -1019,13 +1027,13 @@ public class Client {
 		return colorMessage;
 	}
 	
-	public static void drawNPC(int x, int y, int width, int height, String name) {
+	public static void drawNPC(int x, int y, int width, int height, String name, int currentHits, int maxHits) {
 		// ILOAD 6 is index
-		npc_list.add(new NPC(x, y, width, height, name, NPC.TYPE_MOB));
+		npc_list.add(new NPC(x, y, width, height, name, NPC.TYPE_MOB, currentHits, maxHits));
 	}
 	
-	public static void drawPlayer(int x, int y, int width, int height, String name) {
-		npc_list.add(new NPC(x, y, width, height, name, NPC.TYPE_PLAYER));
+	public static void drawPlayer(int x, int y, int width, int height, String name, int currentHits, int maxHits) {
+		npc_list.add(new NPC(x, y, width, height, name, NPC.TYPE_PLAYER, currentHits, maxHits));
 	}
 	
 	public static void drawItem(int x, int y, int width, int height, int id) {

--- a/src/Game/NPC.java
+++ b/src/Game/NPC.java
@@ -32,14 +32,18 @@ class NPC {
 	public int height;
 	public String name;
 	public int type;
+	public int currentHits;
+	public int maxHits;
 	
-	public NPC(int x, int y, int width, int height, String name, int type) {
+	public NPC(int x, int y, int width, int height, String name, int type, int currentHits, int maxHits) {
 		this.x = x;
 		this.y = y;
 		this.width = width;
 		this.height = height;
 		this.name = name;
 		this.type = type;
+		this.currentHits = currentHits;
+		this.maxHits = maxHits;
 	}
 	
 }

--- a/src/Game/Reflection.java
+++ b/src/Game/Reflection.java
@@ -33,8 +33,16 @@ import Client.Logger;
 public class Reflection {
 	
 	public static Field characterName = null;
+	public static Field characterDisplayName = null;
+	public static Field characterX = null;
+	public static Field characterY = null;
+	public static Field characterDamageTaken = null;
+	public static Field characterCurrentHits = null;
+	public static Field characterMaxHits = null;
 	public static Field characterWaypointX = null;
 	public static Field characterWaypointY = null;
+	public static Field attackingPlayerIdx = null;
+	public static Field attackingNpcIdx = null;
 	
 	public static Field maxInventory = null;
 	
@@ -182,14 +190,38 @@ public class Reflection {
 			// Character
 			c = classLoader.loadClass("ta");
 			characterName = c.getDeclaredField("C");
+			characterDisplayName = c.getDeclaredField("c");
+			characterX = c.getDeclaredField("i");
+			characterY = c.getDeclaredField("K");
+			characterDamageTaken = c.getDeclaredField("u");
+			characterCurrentHits = c.getDeclaredField("B");
+			characterMaxHits = c.getDeclaredField("G");
 			characterWaypointX = c.getDeclaredField("i");
 			characterWaypointY = c.getDeclaredField("K");
+			attackingPlayerIdx = c.getDeclaredField("z");
+			attackingNpcIdx = c.getDeclaredField("h");
 			if (characterName != null)
 				characterName.setAccessible(true);
+			if (characterDisplayName != null)
+				characterDisplayName.setAccessible(true);
+			if (characterX != null)
+				characterX.setAccessible(true);
+			if (characterY != null)
+				characterY.setAccessible(true);
+			if (characterDamageTaken != null)
+				characterDamageTaken.setAccessible(true);
+			if (characterCurrentHits != null)
+				characterCurrentHits.setAccessible(true);
+			if (characterMaxHits != null)
+				characterMaxHits.setAccessible(true);
 			if (characterWaypointX != null)
 				characterWaypointX.setAccessible(true);
 			if (characterWaypointY != null)
 				characterWaypointY.setAccessible(true);
+			if (attackingPlayerIdx != null)
+				attackingPlayerIdx.setAccessible(true);
+			if (attackingNpcIdx != null)
+				attackingNpcIdx.setAccessible(true);
 			
 			// Menu
 			c = classLoader.loadClass("qa");

--- a/src/Game/Renderer.java
+++ b/src/Game/Renderer.java
@@ -193,6 +193,9 @@ public class Renderer {
 				List<Rectangle> player_hitbox = new ArrayList<>();
 				List<Point> entity_text_loc = new ArrayList<>();
 				
+				float alphaHP = 1.0f;
+				Color colorHP = color_hp;
+				
 				for (Iterator<NPC> iterator = Client.npc_list.iterator(); iterator.hasNext();) {
 					NPC npc = iterator.next(); // TODO: Remove unnecessary allocations
 					Color color = color_low;
@@ -238,15 +241,22 @@ public class Renderer {
 						}
 					}
 					
-					if (show && npc.name != null) {
+					if (Settings.SHOW_STATUSDISPLAY && npc.name != null) {
 						int x = npc.x + (npc.width / 2);
 						int y = npc.y - 20;
+						if (Client.player_name == null)
+							Client.getPlayerName();
 						for (Iterator<Point> locIterator = entity_text_loc.iterator(); locIterator.hasNext();) {
 							Point loc = locIterator.next(); // TODO: Remove unnecessary allocations
 							if (loc.x == x && loc.y == y)
 								y -= 12;
 						}
-						drawShadowText(g2, npc.name, x, y, color, true);
+						if (Client.isInCombat() && npc.currentHits != 0 && npc.maxHits != 0 && !npc.name.equals(Client.player_name)) {
+							drawShadowText(g2, npc.currentHits + "/" + npc.maxHits, x, y + 10, color, true);
+						}
+						if (show) {
+							drawShadowText(g2, npc.name, x, y, color, true);
+						}
 						entity_text_loc.add(new Point(x, y));
 					}
 				}
@@ -403,17 +413,8 @@ public class Renderer {
 						drawShadowText(g2, "Fatigue: " + Client.getFatigue() + "/100", x, y, colorFatigue, false);
 						y += 16;
 						setAlpha(g2, 1.0f);
-						if (Client.isInCombat()) {
-							setAlpha(g2, 1.0f);
-							drawShadowText(g2, "Opponent's Hits: " + Client.opponentCurrHealth + "/" + Client.opponentMaxHealth, x, y, colorHP, false);
-							y += 16;
-							setAlpha(g2, 1.0f);
-						}
 					}
 				} else {
-					if (Client.isInCombat()) {
-						drawBar(g2, image_bar_frame, width / 2 - 30, height / 2 - 120, colorHP, alphaHP, Client.opponentCurrHealth, Client.opponentMaxHealth);
-					}
 					int barSize = 4 + image_bar_frame.getWidth(null);
 					int x2 = width - (4 + barSize);
 					int y2 = height - image_bar_frame.getHeight(null);


### PR DESCRIPTION
The display of hits status on other npc/players can be made prettier, if someone wants to pick it up from there. Fixes display overwriting when many combat scenarios are around.