### PR TITLE
Launcher: Update client if new version is detected

### DIFF
--- a/src/Client/ConfigWindow.java
+++ b/src/Client/ConfigWindow.java
@@ -71,7 +71,6 @@ import javax.swing.event.ChangeEvent;
 import javax.swing.event.ChangeListener;
 import javax.swing.plaf.nimbus.NimbusLookAndFeel;
 import Client.KeybindSet.KeyModifier;
-import Client.Util;
 import Game.Camera;
 import Game.Game;
 import Game.KeyboardHandler;
@@ -126,6 +125,7 @@ public class ConfigWindow {
 	private JCheckBox generalPanelClientSizeCheckbox;
 	private JSpinner generalPanelClientSizeXSpinner;
 	private JSpinner generalPanelClientSizeYSpinner;
+	private JCheckBox generalPanelCheckUpdates;
 	private JCheckBox generalPanelChatHistoryCheckbox;
 	private JCheckBox generalPanelCombatXPMenuCheckbox;
 	private JCheckBox generalPanelXPDropsCheckbox;
@@ -415,6 +415,9 @@ public class ConfigWindow {
 		spinnerWinYModel.setValue(346);
 		spinnerWinYModel.setStepSize(10);
 		generalPanelClientSizeYSpinner.setModel(spinnerWinYModel);
+		
+		generalPanelCheckUpdates = addCheckbox("Check for rscplus updates from GitHub at launch", generalPanel);
+		generalPanelCheckUpdates.setToolTipText("When enabled, rscplus will check for client updates before launching the game and install them when prompted");
 		
 		generalPanelChatHistoryCheckbox = addCheckbox("Load chat history after relogging (Not implemented yet)", generalPanel);
 		generalPanelChatHistoryCheckbox.setToolTipText("Make chat history persist between logins");
@@ -1140,6 +1143,7 @@ public class ConfigWindow {
 		generalPanelClientSizeCheckbox.setSelected(Settings.CUSTOM_CLIENT_SIZE);
 		generalPanelClientSizeXSpinner.setValue(Settings.CUSTOM_CLIENT_SIZE_X);
 		generalPanelClientSizeYSpinner.setValue(Settings.CUSTOM_CLIENT_SIZE_Y);
+		generalPanelCheckUpdates.setSelected(Settings.CHECK_UPDATES);
 		generalPanelChatHistoryCheckbox.setSelected(Settings.LOAD_CHAT_HISTORY); // TODO: Implement this feature
 		generalPanelCombatXPMenuCheckbox.setSelected(Settings.COMBAT_MENU);
 		generalPanelXPDropsCheckbox.setSelected(Settings.SHOW_XPDROPS);
@@ -1231,6 +1235,7 @@ public class ConfigWindow {
 		Settings.CUSTOM_CLIENT_SIZE = generalPanelClientSizeCheckbox.isSelected();
 		Settings.CUSTOM_CLIENT_SIZE_X = ((SpinnerNumberModel)(generalPanelClientSizeXSpinner.getModel())).getNumber().intValue();
 		Settings.CUSTOM_CLIENT_SIZE_Y = ((SpinnerNumberModel)(generalPanelClientSizeYSpinner.getModel())).getNumber().intValue();
+		Settings.CHECK_UPDATES = generalPanelCheckUpdates.isSelected();
 		Settings.LOAD_CHAT_HISTORY = generalPanelChatHistoryCheckbox.isSelected();
 		Settings.COMBAT_MENU = generalPanelCombatXPMenuCheckbox.isSelected();
 		Settings.SHOW_XPDROPS = generalPanelXPDropsCheckbox.isSelected();

--- a/src/Client/Settings.java
+++ b/src/Client/Settings.java
@@ -46,7 +46,7 @@ public class Settings {
 	// Internally used variables
 	public static boolean fovUpdateRequired;
 	public static boolean versionCheckRequired = true;
-	public static final double VERSION_NUMBER = 20180522.034227;
+	public static final double VERSION_NUMBER = 20180522.014227;
 	/**
 	 * A time stamp corresponding to the current version of this source code. Used as a sophisticated versioning system.
 	 *
@@ -70,6 +70,7 @@ public class Settings {
 	public static boolean CUSTOM_CLIENT_SIZE = false;
 	public static int CUSTOM_CLIENT_SIZE_X = 512;
 	public static int CUSTOM_CLIENT_SIZE_Y = 346;
+	public static boolean CHECK_UPDATES = true;
 	public static boolean LOAD_CHAT_HISTORY = false;
 	public static boolean COMBAT_MENU = false;
 	public static boolean SHOW_XPDROPS = true;
@@ -143,6 +144,7 @@ public class Settings {
 	public static int COMBAT_STYLE = Client.COMBAT_AGGRESSIVE;
 	public static int WORLD = 2;
 	public static boolean FIRST_TIME = true;
+	public static boolean UPDATE_CONFIRMATION = false;
 	public static boolean DISASSEMBLE = false;
 	public static String DISASSEMBLE_DIRECTORY = "dump";
 	
@@ -194,6 +196,7 @@ public class Settings {
 			CUSTOM_CLIENT_SIZE = getBoolean(props, "custom_client_size", CUSTOM_CLIENT_SIZE);
 			CUSTOM_CLIENT_SIZE_X = getInt(props, "custom_client_size_x", CUSTOM_CLIENT_SIZE_X);
 			CUSTOM_CLIENT_SIZE_Y = getInt(props, "custom_client_size_y", CUSTOM_CLIENT_SIZE_Y);
+			CHECK_UPDATES = getBoolean(props, "check_updates", CHECK_UPDATES);
 			LOAD_CHAT_HISTORY = getBoolean(props, "load_chat_history", LOAD_CHAT_HISTORY);
 			COMBAT_MENU = getBoolean(props, "combat_menu", COMBAT_MENU);
 			SHOW_XPDROPS = getBoolean(props, "show_xpdrops", SHOW_XPDROPS);
@@ -251,6 +254,7 @@ public class Settings {
 			WORLD = getInt(props, "world", 2);
 			COMBAT_STYLE = getInt(props, "combat_style", Client.COMBAT_AGGRESSIVE);
 			FIRST_TIME = getBoolean(props, "first_time", FIRST_TIME);
+			UPDATE_CONFIRMATION = getBoolean(props, "update_confirmation", UPDATE_CONFIRMATION);
 			DISASSEMBLE = getBoolean(props, "disassemble", false);
 			DISASSEMBLE_DIRECTORY = getString(props, "disassemble_directory", "dump");
 			
@@ -347,6 +351,7 @@ public class Settings {
 			props.setProperty("custom_client_size", Boolean.toString(CUSTOM_CLIENT_SIZE));
 			props.setProperty("custom_client_size_x", Integer.toString(CUSTOM_CLIENT_SIZE_X));
 			props.setProperty("custom_client_size_y", Integer.toString(CUSTOM_CLIENT_SIZE_Y));
+			props.setProperty("check_updates", Boolean.toString(CHECK_UPDATES));
 			props.setProperty("load_chat_history", Boolean.toString(LOAD_CHAT_HISTORY));
 			props.setProperty("combat_menu", Boolean.toString(COMBAT_MENU));
 			props.setProperty("show_xpdrops", Boolean.toString(SHOW_XPDROPS));
@@ -405,6 +410,7 @@ public class Settings {
 			props.setProperty("combat_style", Integer.toString(COMBAT_STYLE));
 			// This is set to false, as logically, saving the config would imply this is not a first-run.
 			props.setProperty("first_time", Boolean.toString(false));
+			props.setProperty("update_confirmation", Boolean.toString(UPDATE_CONFIRMATION));
 			props.setProperty("disassemble", Boolean.toString(DISASSEMBLE));
 			props.setProperty("disassemble_directory", "" + DISASSEMBLE_DIRECTORY);
 			

--- a/src/Game/Client.java
+++ b/src/Game/Client.java
@@ -831,9 +831,9 @@ public class Client {
 			displayMessage("@mag@Type @yel@::help@mag@ for a list of commands", CHAT_QUEST);
 			displayMessage("@mag@Open the settings with @yel@" + configWindowShortcut + "@mag@ or @yel@right-click the tray icon", CHAT_QUEST);
 			
-			// Check to see if RSC+ is up to date
-			if (Settings.versionCheckRequired) {
-				Settings.versionCheckRequired = false;
+			// Check for updates every login, so users are notified when an update is available
+			if (Settings.CHECK_UPDATES) {
+				// TODO: Maybe we should only check this 1 time per hour, or so.
 				checkForUpdate(false);
 			}
 		}


### PR DESCRIPTION
This change introduces an automatic updater than can be turned off, and the user is prompted to disable it/enable it. It also adds a new setting to the settings interface to toggle this option.

Hopefully now our users can stay updated easier.