### PR TITLE
Draw NPC info for what the player is attacking

### DIFF
--- a/src/Client/Settings.java
+++ b/src/Client/Settings.java
@@ -46,7 +46,7 @@ public class Settings {
 	// Internally used variables
 	public static boolean fovUpdateRequired;
 	public static boolean versionCheckRequired = true;
-	public static final double VERSION_NUMBER = 20180522.200651;
+	public static final double VERSION_NUMBER = 20180522.221121;
 	/**
 	 * A time stamp corresponding to the current version of this source code. Used as a sophisticated versioning system.
 	 *

--- a/src/Game/Client.java
+++ b/src/Game/Client.java
@@ -139,6 +139,8 @@ public class Client {
 	public static String player_name = null;
 	public static int player_posX = -1;
 	public static int player_posY = -1;
+	public static int player_height = -1;
+	public static int player_width = -1;
 	
 	public static int regionX = -1;
 	public static int regionY = -1;

--- a/src/Game/Renderer.java
+++ b/src/Game/Renderer.java
@@ -97,6 +97,7 @@ public class Renderer {
 	private static int frames = 0;
 	private static long fps_timer = 0;
 	private static boolean screenshot = false;
+	private static int current_boost_count = 0;
 	
 	public static String[] shellStrings;
 	
@@ -439,6 +440,8 @@ public class Renderer {
 					x2 -= barSize;
 				}
 			}
+			
+			current_boost_count = 0;
 			// Draw under combat style info
 			if (!Client.isInterfaceOpen()) {
 				if (time <= Client.magic_timer) {
@@ -461,6 +464,8 @@ public class Renderer {
 						drawShadowText(g2, boost, x, y, color, false);
 						drawShadowText(g2, Client.skill_name[i], x + 32, y, color, false);
 						y += 14;
+						
+						current_boost_count++;
 					}
 				}
 			}
@@ -740,7 +745,7 @@ public class Renderer {
 	}
 	
 	private static void drawNPCBar(Graphics2D g, NPC npc) {
-		Dimension bounds = new Dimension(173, 45);
+		Dimension bounds = new Dimension(173, 46);
 		float hp_ratio = (float)(npc.currentHits) / (float)(npc.maxHits);
 		int x = 7;
 		int y = 137;
@@ -749,6 +754,9 @@ public class Renderer {
 			// +48 to shift below fatigue, HP, prayer when showing on the left side
 			y += 48;
 		}
+		
+		// Adjust position for any boosts drawn on screen
+		y += (current_boost_count * 14);
 		
 		// Container
 		setAlpha(g, 0.5f);

--- a/src/Game/Renderer.java
+++ b/src/Game/Renderer.java
@@ -206,7 +206,7 @@ public class Renderer {
 					}
 					
 					// Update player coords
-					if (npc.name.equals(Client.player_name)) {
+					if (npc != null && Client.player_name.equals(npc.name)) {
 						Client.player_posX = npc.x;
 						Client.player_posY = npc.y;
 						Client.player_height = npc.height;
@@ -267,6 +267,9 @@ public class Renderer {
 						}
 						if (show) {
 							drawShadowText(g2, npc.name, x, y, color, true);
+							if (npc.currentHits != 0 && npc.maxHits != 0) {
+								drawShadowText(g2, npc.currentHits + "/" + npc.maxHits, x, y - 12, color, true);
+							}
 						}
 						entity_text_loc.add(new Point(x, y));
 					}
@@ -739,13 +742,14 @@ public class Renderer {
 		return Client.isInCombat() &&
 				npc.currentHits != 0 &&
 				npc.maxHits != 0 &&
-				!npc.name.equals(Client.player_name) &&
+				npc != null &&
+				!Client.player_name.equals(npc.name) &&
 				inCombatCandidate &&
 				hitboxesIntersectOnXAxis;
 	}
 	
 	private static void drawNPCBar(Graphics2D g, NPC npc) {
-		Dimension bounds = new Dimension(173, 46);
+		Dimension bounds = new Dimension(173, 40);
 		float hp_ratio = (float)(npc.currentHits) / (float)(npc.maxHits);
 		int x = 7;
 		int y = 137;
@@ -768,15 +772,15 @@ public class Renderer {
 		// HP bar
 		setAlpha(g, 1.0f);
 		g.setColor(new Color(99, 20, 19));
-		g.fillRect(x, y + 23, bounds.width, bounds.height / 2);
+		g.fillRect(x, y + 20, bounds.width, bounds.height / 2);
 		g.setColor(new Color(10, 134, 51));
-		g.fillRect(x, y + 23, (int)(bounds.width * hp_ratio), bounds.height / 2);
+		g.fillRect(x, y + 20, (int)(bounds.width * hp_ratio), bounds.height / 2);
 		
 		// HP text
-		drawShadowText(g, npc.currentHits + "/" + npc.maxHits, x + (bounds.width / 2), y + (bounds.height / 2) + 10, color_text, true);
+		drawShadowText(g, npc.currentHits + "/" + npc.maxHits, x + (bounds.width / 2), y + (bounds.height / 2) + 8, color_text, true);
 		
 		// NPC name
-		drawShadowText(g, npc.name, x + (bounds.width / 2), y + (bounds.height / 2) - 14, color_text, true);
+		drawShadowText(g, npc.name, x + (bounds.width / 2), y + (bounds.height / 2) - 12, color_text, true);
 	}
 	
 }


### PR DESCRIPTION
![npc-combat-info](https://user-images.githubusercontent.com/10540865/40388871-bbf109e6-5dde-11e8-9b25-37cdc6506ebb.png)

It's tricky to figure out what NPC you're fighting, but I figured out a few tricks to make this almost perfect.

 - The NPC and player will have the same bottom Y position when in combat with each other (y coord + height)
 - The NPC and player's hitboxes will always (from what I've tested) intersect on the X axis

Using these two criteria, along with the other obvious bits (like having hp info and while the player is actually in combat), this will almost always choose the correct NPC.

It _can_ fail if another player is in combat on top of you and you have your camera rotated a certain way, but when this happens the other monster's info will just be written on top of the one you're actually fighting, so it's not really a big deal, especially for how rare this can happen. 