### PR TITLE
Improve combat NPC algorithm

### DIFF
--- a/src/Client/Settings.java
+++ b/src/Client/Settings.java
@@ -46,7 +46,7 @@ public class Settings {
 	// Internally used variables
 	public static boolean fovUpdateRequired;
 	public static boolean versionCheckRequired = true;
-	public static final double VERSION_NUMBER = 20180522.230904;
+	public static final double VERSION_NUMBER = 20180523.022824;
 	/**
 	 * A time stamp corresponding to the current version of this source code. Used as a sophisticated versioning system.
 	 *

--- a/src/Game/Renderer.java
+++ b/src/Game/Renderer.java
@@ -749,12 +749,16 @@ public class Renderer {
 		// don't follow this pattern exactly.
 		boolean hitboxesIntersectOnXAxis = (Client.player_posX - 10) < (npc.x + npc.width);
 		
+		// The NPC you're fighting is always on the left side of the player.
+		boolean isOnLeftOfPlayer = Client.player_posX > npc.x;
+		
 		return Client.isInCombat() &&
 				npc.currentHits != 0 &&
 				npc.maxHits != 0 &&
 				npc != null &&
 				!Client.player_name.equals(npc.name) &&
 				inCombatCandidate &&
+				isOnLeftOfPlayer &&
 				hitboxesIntersectOnXAxis;
 	}
 	


### PR DESCRIPTION
Just adds a check for the NPC being on the left of the player. Must've forgotten to add this in the first place.

This should remove tracking NPC's that are on the same level as you but to the right.