### PR TITLE
Edible item fix for discontinued and quest-only

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ will push it to the end of the bank and thus withdrawing all should not
 be done if your bank is tidy. To exit the search mode, speak to the 
 banker again.
 
-*::togglestartsearchedbank <aWord>* - Toggle between searchable bank 
+*::togglestartsearchedbank [[aWord]]* - Toggle between searchable bank 
 mode and normal mode; specifying the parameter updates the search 
 keyword stored.
 
@@ -154,6 +154,17 @@ keyword stored.
     <li>Purely practical name changes (potion dosages, unidentified herbs, unfinished potions)</li>
     <li>Capitalizations and fixed spellings on top of type 1 changes</li>
     <li>Reworded vague stuff to be more descriptive on top of type 1 & 2 changes</li>
+  </ol></dd>
+  </dd>
+
+  <dt>command_patch_type</dt>
+  <dd>Range: <i>0 to 3</i><br>
+  Sets how edible items are patched:<br>
+  <ol start=0>
+    <li>No item command patching</li>
+    <li>Remove eat/drink option from discontinued rares (pumpkin, easter egg, etc.)</li>
+    <li>Swap the eat/drink option with use for quest-only items (chocolaty milky, nightshade, etc.)</li>
+    <li>Apply both 1 & 2 changes</li>
   </ol></dd>
   </dd>
   

--- a/src/Client/ConfigWindow.java
+++ b/src/Client/ConfigWindow.java
@@ -108,6 +108,7 @@ public class ConfigWindow {
 	private JFrame frame;
 	
 	private JLabel generalPanelNamePatchModeDesc;
+	private JLabel generalPanelCommandPatchModeDesc;
 	private JLabel notificationPanelLowHPNotifsEndLabel;
 	private JLabel notificationPanelFatigueNotifsEndLabel;
 	
@@ -136,6 +137,7 @@ public class ConfigWindow {
 	private JCheckBox generalPanelFatigueAlertCheckbox;
 	private JCheckBox generalPanelInventoryFullAlertCheckbox;
 	private JSlider generalPanelNamePatchModeSlider;
+	private JSlider generalPanelCommandPatchModeSlider;
 	private JCheckBox generalPanelRoofHidingCheckbox;
 	private JCheckBox generalPanelColoredTextCheckbox;
 	private JSlider generalPanelFoVSlider;
@@ -522,6 +524,61 @@ public class ConfigWindow {
 					break;
 				default:
 					Logger.Error("Invalid name patch mode value");
+					break;
+				}
+			}
+		});
+		
+		JPanel generalPanelCommandPatchModePanel = new JPanel();
+		generalPanelCommandPatchModePanel.setAlignmentX(Component.LEFT_ALIGNMENT);
+		generalPanelCommandPatchModePanel.setMaximumSize(new Dimension(300, 60));
+		generalPanelCommandPatchModePanel.setLayout(new BoxLayout(generalPanelCommandPatchModePanel, BoxLayout.X_AXIS));
+		generalPanel.add(generalPanelCommandPatchModePanel);
+		
+		generalPanelCommandPatchModeSlider = new JSlider();
+		generalPanelCommandPatchModeSlider.setMajorTickSpacing(1);
+		generalPanelCommandPatchModeSlider.setPaintLabels(true);
+		generalPanelCommandPatchModeSlider.setPaintTicks(true);
+		generalPanelCommandPatchModeSlider.setSnapToTicks(true);
+		generalPanelCommandPatchModeSlider.setMinimum(0);
+		generalPanelCommandPatchModeSlider.setMaximum(3);
+		generalPanelCommandPatchModeSlider.setPreferredSize(new Dimension(33, 0));
+		generalPanelCommandPatchModeSlider.setAlignmentX(Component.LEFT_ALIGNMENT);
+		generalPanelCommandPatchModeSlider.setBorder(new EmptyBorder(0, 0, 5, 0));
+		generalPanelCommandPatchModeSlider.setOrientation(SwingConstants.VERTICAL);
+		generalPanelCommandPatchModePanel.add(generalPanelCommandPatchModeSlider);
+		
+		JPanel generalPanelCommandPatchModeTextPanel = new JPanel();
+		generalPanelCommandPatchModeTextPanel.setPreferredSize(new Dimension(255, 55));
+		generalPanelCommandPatchModeTextPanel.setLayout(new BorderLayout());
+		generalPanelCommandPatchModeTextPanel.setBorder(new EmptyBorder(0, 10, 0, 0));
+		generalPanelCommandPatchModePanel.add(generalPanelCommandPatchModeTextPanel);
+		
+		JLabel generalPanelCommandPatchModeTitle = new JLabel("<html><b>Item command patch mode</b> (Requires restart)</html>");
+		generalPanelCommandPatchModeTitle.setToolTipText("Reworks certain discontinued/quest-only item edible commands with improved versions");
+		generalPanelCommandPatchModeTextPanel.add(generalPanelCommandPatchModeTitle, BorderLayout.PAGE_START);
+		generalPanelCommandPatchModeDesc = new JLabel("");
+		generalPanelCommandPatchModeTextPanel.add(generalPanelCommandPatchModeDesc, BorderLayout.CENTER);
+		
+		generalPanelCommandPatchModeSlider.addChangeListener(new ChangeListener() {
+			
+			@Override
+			public void stateChanged(ChangeEvent e) {
+				switch (generalPanelCommandPatchModeSlider.getValue()) {
+				case 3:
+					generalPanelCommandPatchModeDesc.setText("<html>Apply both 1 & 2 changes</html>");
+					break;
+				case 2:
+					generalPanelCommandPatchModeDesc.setText("<html>Swap eat/drink option with use on quest-only items</html>");
+					break;
+				case 1:
+					generalPanelCommandPatchModeDesc.setText("<html>Remove eat/drink option on discontinued items</html>");
+					break;
+				case 0:
+					generalPanelCommandPatchModeDesc.setText("<html>No item command patching</html>");
+					break;
+				default:
+					Logger.Error("Invalid command patch mode value");
 					break;
 				}
 			}
@@ -1156,6 +1213,7 @@ public class ConfigWindow {
 		generalPanelFatigueAlertCheckbox.setSelected(Settings.FATIGUE_ALERT);
 		generalPanelInventoryFullAlertCheckbox.setSelected(Settings.INVENTORY_FULL_ALERT);
 		generalPanelNamePatchModeSlider.setValue(Settings.NAME_PATCH_TYPE);
+		generalPanelCommandPatchModeSlider.setValue(Settings.COMMAND_PATCH_TYPE);
 		generalPanelRoofHidingCheckbox.setSelected(Settings.HIDE_ROOFS);
 		generalPanelColoredTextCheckbox.setSelected(Settings.COLORIZE);
 		generalPanelFoVSlider.setValue(Settings.FOV);
@@ -1245,6 +1303,7 @@ public class ConfigWindow {
 		Settings.FATIGUE_ALERT = generalPanelFatigueAlertCheckbox.isSelected();
 		Settings.INVENTORY_FULL_ALERT = generalPanelInventoryFullAlertCheckbox.isSelected();
 		Settings.NAME_PATCH_TYPE = generalPanelNamePatchModeSlider.getValue();
+		Settings.COMMAND_PATCH_TYPE = generalPanelCommandPatchModeSlider.getValue();
 		Settings.HIDE_ROOFS = generalPanelRoofHidingCheckbox.isSelected();
 		Settings.COLORIZE = generalPanelColoredTextCheckbox.isSelected();
 		Settings.FOV = generalPanelFoVSlider.getValue();

--- a/src/Client/Settings.java
+++ b/src/Client/Settings.java
@@ -46,7 +46,7 @@ public class Settings {
 	// Internally used variables
 	public static boolean fovUpdateRequired;
 	public static boolean versionCheckRequired = true;
-	public static final double VERSION_NUMBER = 20180523.022824;
+	public static final double VERSION_NUMBER = 20180523.063813;
 	/**
 	 * A time stamp corresponding to the current version of this source code. Used as a sophisticated versioning system.
 	 *
@@ -89,6 +89,16 @@ public class Settings {
 	 * </p>
 	 */
 	public static int NAME_PATCH_TYPE = 3;
+	/**
+	 * Defines to what extent fix the item commands should be patched.
+	 * <p>
+	 * 0 - No item command patching<br>
+	 * 1 - Disable item consumption on discontinued rares<br>
+	 * 2 - Swap item command, i.e. use instead of consuming on quest-only items<br>
+	 * 3 - Apply both fixes 1 and 2
+	 * </p>
+	 */
+	public static int COMMAND_PATCH_TYPE = 3;
 	public static boolean HIDE_ROOFS = true;
 	public static boolean COLORIZE = true; // TODO: Vague, consider refactoring for clarity
 	public static int FOV = 9;
@@ -205,6 +215,7 @@ public class Settings {
 			FATIGUE_ALERT = getBoolean(props, "fatigue_alert", FATIGUE_ALERT);
 			INVENTORY_FULL_ALERT = getBoolean(props, "inventory_full_alert", INVENTORY_FULL_ALERT);
 			NAME_PATCH_TYPE = getInt(props, "name_patch_type", NAME_PATCH_TYPE);
+			COMMAND_PATCH_TYPE = getInt(props, "command_patch_type", COMMAND_PATCH_TYPE);
 			HIDE_ROOFS = getBoolean(props, "hide_roofs", HIDE_ROOFS);
 			COLORIZE = getBoolean(props, "colorize", COLORIZE);
 			FOV = getInt(props, "fov", FOV);
@@ -301,6 +312,14 @@ public class Settings {
 				save();
 			}
 			
+			if (COMMAND_PATCH_TYPE < 0) {
+				COMMAND_PATCH_TYPE = 0;
+				save();
+			} else if (COMMAND_PATCH_TYPE > 3) {
+				COMMAND_PATCH_TYPE = 3;
+				save();
+			}
+			
 			if (FATIGUE_FIGURES < 1) {
 				FATIGUE_FIGURES = 1;
 				save();
@@ -360,6 +379,7 @@ public class Settings {
 			props.setProperty("fatigue_alert", Boolean.toString(FATIGUE_ALERT));
 			props.setProperty("inventory_full_alert", Boolean.toString(INVENTORY_FULL_ALERT));
 			props.setProperty("name_patch_type", Integer.toString(NAME_PATCH_TYPE));
+			props.setProperty("command_patch_type", Integer.toString(COMMAND_PATCH_TYPE));
 			props.setProperty("hide_roofs", Boolean.toString(HIDE_ROOFS));
 			props.setProperty("colorize", Boolean.toString(COLORIZE));
 			props.setProperty("fov", Integer.toString(FOV));
@@ -942,6 +962,7 @@ public class Settings {
 		FATIGUE_ALERT = true;
 		INVENTORY_FULL_ALERT = false;
 		NAME_PATCH_TYPE = 3;
+		COMMAND_PATCH_TYPE = 3;
 		HIDE_ROOFS = true;
 		COLORIZE = true;
 		FOV = 9;

--- a/src/Game/Client.java
+++ b/src/Game/Client.java
@@ -28,6 +28,7 @@ import java.io.BufferedWriter;
 import java.io.File;
 import java.io.FileWriter;
 import java.io.InputStreamReader;
+import java.lang.reflect.InvocationTargetException;
 import java.net.URL;
 import java.net.URLConnection;
 import java.util.ArrayList;
@@ -755,6 +756,65 @@ public class Client {
 		} else if (announceIfUpToDate) {
 			displayMessage("You're up to date: @gre@" + String.format("%8.6f", latestVersion), CHAT_QUEST);
 		}
+	}
+	
+	/**
+	 * Index fix after menu swap of redrawMenuHook
+	 * 
+	 * @param menuindex - the index of the menu
+	 * @return the fixed index
+	 */
+	public static int swapUseMenuHook(int menuindex) {
+		int newmenuindex = menuindex;
+		if (newmenuindex == 635) {
+			newmenuindex = 650;
+		} else {
+		}
+		return newmenuindex;
+	}
+	
+	/**
+	 * Redraw right click menu add item hook, only interested from the portion of items with special commands 640 or
+	 * none
+	 * 
+	 * @param instance - the instance of common menu
+	 * @param n - some index sent over
+	 * @param index - the item index
+	 * @param itemCommand - item command
+	 * @param itemName - item name
+	 */
+	public static void redrawMenuHook(Object instance, int n, int index, String itemCommand, String itemName) {
+		
+		if (instance != null) {
+			try {
+				// Client.strings[34] - @lre@
+				if (!itemCommand.equals("")) {
+					if (!Item.shouldPatch(index)) {
+						// Edible item command
+						Reflection.menuGen.invoke(instance, n, 640, false, itemCommand, Client.strings[34] + itemName);
+						// Use
+						Reflection.menuGen.invoke(instance, n, 650, false, Client.strings[71], Client.strings[34] + itemName);
+					} else {
+						// 635 is a synonym for 650 "Use", its lower than 640 since otherwise won't do the swap
+						// Use
+						Reflection.menuGen.invoke(instance, n, 635, false, Client.strings[71], Client.strings[34] + itemName);
+						// Edible item command
+						Reflection.menuGen.invoke(instance, n, 640, false, itemCommand, Client.strings[34] + itemName);
+					}
+				} else {
+					// Use
+					Reflection.menuGen.invoke(instance, n, 650, false, Client.strings[71], Client.strings[34] + itemName);
+				}
+				// Drop
+				Reflection.menuGen.invoke(instance, n, 660, false, Client.strings[67], Client.strings[34] + itemName);
+				// Examine
+				Reflection.menuGen.invoke(instance, index, 3600, false, Client.strings[51], Client.strings[34] + itemName);
+			} catch (IllegalAccessException | IllegalArgumentException | InvocationTargetException e) {
+				// TODO Auto-generated catch block
+				e.printStackTrace();
+			}
+		}
+		
 	}
 	
 	// combat packet received (testing only, the info is taken on function that draws hits)

--- a/src/Game/Item.java
+++ b/src/Game/Item.java
@@ -38,6 +38,7 @@ import Client.Settings;
 public class Item {
 	
 	public static String[] item_name;
+	public static String[] item_commands;
 	
 	public int x;
 	public int y;
@@ -129,6 +130,44 @@ public class Item {
 		} catch (SQLException e) {
 			Logger.Error("Error patching item names from database values.");
 			e.printStackTrace();
+		}
+	}
+	
+	/**
+	 * Patches discontinued edible item commands specified by {@link Settings#COMMAND_PATCH_TYPE}.
+	 * Removes completely the option to eat/drink
+	 */
+	public static void patchItemCommands() {
+		int commandPatchType = Settings.COMMAND_PATCH_TYPE;
+		// ids of Half full wine jug, Disk of Returning, Pumpkin, Easter egg
+		int[] edible_rare_item_ids = { 246, 387, 422, 677 };
+		
+		if (commandPatchType == 1 || commandPatchType == 3) {
+			for (int i : edible_rare_item_ids) {
+				item_commands[i] = "";
+			}
+		}
+	}
+	
+	/**
+	 * Patches quest only edible item commands specified by {@link Settings#COMMANDS_PATCH_TYPE}.
+	 * Swaps around the option to eat/drink
+	 */
+	public static boolean shouldPatch(int index) {
+		int commandPatchType = Settings.COMMAND_PATCH_TYPE;
+		// ids of giant Carp, chocolaty milk, Rock cake, nightshade
+		int[] edible_quest_item_ids = { 718, 770, 1061, 1086 };
+		boolean found = false;
+		if (commandPatchType == 2 || commandPatchType == 3) {
+			for (int i : edible_quest_item_ids) {
+				if (index == i) {
+					found = true;
+					break;
+				}
+			}
+			return found;
+		} else {
+			return false;
 		}
 	}
 	

--- a/src/Game/Reflection.java
+++ b/src/Game/Reflection.java
@@ -59,6 +59,7 @@ public class Reflection {
 	public static Method setLoginText = null;
 	public static Method logout = null;
 	public static Method itemClick = null;
+	public static Method menuGen = null;
 	
 	public static Method newPacket = null;
 	public static Method putShort = null;
@@ -72,6 +73,7 @@ public class Reflection {
 	private static final String SETLOGINTEXT = "private final void client.b(byte,java.lang.String,java.lang.String)";
 	private static final String LOGOUT = "private final void client.B(int)";
 	private static final String ITEMCLICK = "private final void client.b(boolean,int)";
+	private static final String MENUGEN = "final void wb.a(int,int,boolean,java.lang.String,java.lang.String)";
 	
 	private static final String NEWPACKET = "final void b.b(int,int)";
 	private static final String PUTSHORT = "final void tb.e(int,int)";
@@ -234,6 +236,15 @@ public class Reflection {
 			// this menu array I'm not sure whats for
 			menuUknown = c.getDeclaredField("sb");
 			
+			c = classLoader.loadClass("wb");
+			methods = c.getDeclaredMethods();
+			for (Method method : methods) {
+				if (method.toGenericString().equals(MENUGEN)) {
+					menuGen = method;
+					Logger.Info("Found menuGen");
+				}
+			}
+			
 			// Set all accessible
 			if (menuX != null)
 				menuX.setAccessible(true);
@@ -259,6 +270,8 @@ public class Reflection {
 				logout.setAccessible(true);
 			if (itemClick != null)
 				itemClick.setAccessible(true);
+			if (menuGen != null)
+				menuGen.setAccessible(true);
 			if (newPacket != null)
 				newPacket.setAccessible(true);
 			if (putShort != null)


### PR DESCRIPTION
No longer have to worry on eating or drinking for discontinued rares, quest-only items with drink or eat can get their options swapped.