### PR TITLE
Support percentage toggle in settings

### DIFF
--- a/src/Client/ConfigWindow.java
+++ b/src/Client/ConfigWindow.java
@@ -154,6 +154,7 @@ public class ConfigWindow {
 	private JCheckBox overlayPanelFriendNamesCheckbox;
 	private JCheckBox overlayPanelNPCNamesCheckbox;
 	private JCheckBox overlayPanelNPCHitboxCheckbox;
+	private JCheckBox overlayPanelUsePercentageCheckbox;
 	private JCheckBox overlayPanelFoodHealingCheckbox;
 	private JCheckBox overlayPanelHPRegenTimerCheckbox;
 	private JCheckBox overlayPanelDebugModeCheckbox;
@@ -677,6 +678,9 @@ public class ConfigWindow {
 		
 		overlayPanelNPCNamesCheckbox = addCheckbox("Display NPC name overlay", overlayPanel);
 		overlayPanelNPCNamesCheckbox.setToolTipText("Shows NPC names over the NPC");
+		
+		overlayPanelUsePercentageCheckbox = addCheckbox("Use percentage for NPC HP info", overlayPanel);
+		overlayPanelUsePercentageCheckbox.setToolTipText("Uses percentage for NPC HP info instead of actual HP");
 		
 		overlayPanelNPCHitboxCheckbox = addCheckbox("Show character hitboxes", overlayPanel);
 		overlayPanelNPCHitboxCheckbox.setToolTipText("Shows the clickable areas on NPCs and players");
@@ -1249,6 +1253,7 @@ public class ConfigWindow {
 		overlayPanelFriendNamesCheckbox.setSelected(Settings.SHOW_FRIENDINFO);
 		overlayPanelNPCNamesCheckbox.setSelected(Settings.SHOW_NPCINFO);
 		overlayPanelNPCHitboxCheckbox.setSelected(Settings.SHOW_HITBOX);
+		overlayPanelUsePercentageCheckbox.setSelected(Settings.USE_PERCENTAGE);
 		overlayPanelFoodHealingCheckbox.setSelected(Settings.SHOW_FOOD_HEAL_OVERLAY); // TODO: Implement this feature
 		overlayPanelHPRegenTimerCheckbox.setSelected(Settings.SHOW_TIME_UNTIL_HP_REGEN); // TODO: Implement this feature
 		overlayPanelDebugModeCheckbox.setSelected(Settings.DEBUG);
@@ -1320,6 +1325,7 @@ public class ConfigWindow {
 		Settings.SHOW_FRIENDINFO = overlayPanelFriendNamesCheckbox.isSelected();
 		Settings.SHOW_NPCINFO = overlayPanelNPCNamesCheckbox.isSelected();
 		Settings.SHOW_HITBOX = overlayPanelNPCHitboxCheckbox.isSelected();
+		Settings.USE_PERCENTAGE = overlayPanelUsePercentageCheckbox.isSelected();
 		Settings.SHOW_FOOD_HEAL_OVERLAY = overlayPanelFoodHealingCheckbox.isSelected();
 		Settings.SHOW_TIME_UNTIL_HP_REGEN = overlayPanelHPRegenTimerCheckbox.isSelected();
 		Settings.DEBUG = overlayPanelDebugModeCheckbox.isSelected();

--- a/src/Client/Settings.java
+++ b/src/Client/Settings.java
@@ -113,6 +113,7 @@ public class Settings {
 	public static boolean SHOW_PLAYERINFO = false; // TODO: See above
 	public static boolean SHOW_FRIENDINFO = false; // TODO ^
 	public static boolean SHOW_NPCINFO = false; // TODO ^
+	public static boolean USE_PERCENTAGE = false;
 	public static boolean SHOW_HITBOX = false; // TODO: Consider refactoring for clarity that this only affects NPCs
 	public static boolean SHOW_FOOD_HEAL_OVERLAY = false;
 	public static boolean SHOW_TIME_UNTIL_HP_REGEN = false;
@@ -231,6 +232,7 @@ public class Settings {
 			SHOW_PLAYERINFO = getBoolean(props, "show_playerinfo", SHOW_PLAYERINFO);
 			SHOW_FRIENDINFO = getBoolean(props, "show_friendinfo", SHOW_FRIENDINFO);
 			SHOW_NPCINFO = getBoolean(props, "show_npcinfo", SHOW_NPCINFO);
+			USE_PERCENTAGE = getBoolean(props, "use_percentage", DEBUG);
 			SHOW_HITBOX = getBoolean(props, "show_hitbox", SHOW_HITBOX);
 			SHOW_FOOD_HEAL_OVERLAY = getBoolean(props, "show_food_heal_overlay", SHOW_FOOD_HEAL_OVERLAY);
 			SHOW_TIME_UNTIL_HP_REGEN = getBoolean(props, "show_time_until_hp_regen", SHOW_TIME_UNTIL_HP_REGEN);
@@ -395,6 +397,7 @@ public class Settings {
 			props.setProperty("show_playerinfo", Boolean.toString(SHOW_PLAYERINFO));
 			props.setProperty("show_friendinfo", Boolean.toString(SHOW_FRIENDINFO));
 			props.setProperty("show_npcinfo", Boolean.toString(SHOW_NPCINFO));
+			props.setProperty("use_percentage", Boolean.toString(USE_PERCENTAGE));
 			props.setProperty("show_hitbox", Boolean.toString(SHOW_HITBOX));
 			props.setProperty("show_food_heal_overlay", Boolean.toString(SHOW_FOOD_HEAL_OVERLAY));
 			props.setProperty("show_time_until_hp_regen", Boolean.toString(SHOW_TIME_UNTIL_HP_REGEN));
@@ -983,6 +986,7 @@ public class Settings {
 		SHOW_PLAYERINFO = false;
 		SHOW_FRIENDINFO = false;
 		SHOW_NPCINFO = false;
+		USE_PERCENTAGE = false;
 		SHOW_HITBOX = false;
 		SHOW_FOOD_HEAL_OVERLAY = false;
 		SHOW_TIME_UNTIL_HP_REGEN = false;

--- a/src/Game/Renderer.java
+++ b/src/Game/Renderer.java
@@ -814,7 +814,10 @@ public class Renderer {
 		g.fillRect(x, y + 20, (int)(bounds.width * hp_ratio), bounds.height / 2);
 		
 		// HP text
-		drawShadowText(g, npc.currentHits + "/" + npc.maxHits, x + (bounds.width / 2), y + (bounds.height / 2) + 8, color_text, true);
+		if (Settings.USE_PERCENTAGE)
+			drawShadowText(g, (int)(hp_ratio * 100) + "%", x + (bounds.width / 2), y + (bounds.height / 2) + 8, color_text, true);
+		else
+			drawShadowText(g, npc.currentHits + "/" + npc.maxHits, x + (bounds.width / 2), y + (bounds.height / 2) + 8, color_text, true);
 		
 		// NPC name
 		drawShadowText(g, npc.name, x + (bounds.width / 2), y + (bounds.height / 2) - 12, color_text, true);


### PR DESCRIPTION
Simply adds a toggle in the settings for displaying percent of HP remaining when in combat with an NPC opposed to CURRENT_HP/TOTAL_HP