### PR TITLE
Hide Combat Info when Interface is Open

### DIFF
--- a/src/Game/Renderer.java
+++ b/src/Game/Renderer.java
@@ -485,7 +485,7 @@ public class Renderer {
 			}
 			
 			// NPC Post-processing for ui
-			if (Settings.SHOW_COMBAT_INFO) {
+			if (Settings.SHOW_COMBAT_INFO && !Client.isInterfaceOpen()) {
 				for (Iterator<NPC> iterator = Client.npc_list.iterator(); iterator.hasNext();) {
 					NPC npc = iterator.next();
 					if (npc != null && isInCombatWithNPC(npc)) {


### PR DESCRIPTION
This keeps things consistent with other behavior we have with overlays, forgot to add this originally.

Hides the combat info overlay when you have an interface up like sending a PM