### PR TITLE
Adding prayer drain

### DIFF
--- a/src/Client/JClassPatcher.java
+++ b/src/Client/JClassPatcher.java
@@ -150,6 +150,8 @@ public class JClassPatcher {
 			hookClassVariable(methodNode, "lb", "G", "I", "Game/Camera", "distance4", "I", false, true);
 			
 			hookClassVariable(methodNode, "client", "cl", "I", "Game/Client", "max_inventory", "I", true, false);
+			hookClassVariable(methodNode, "client", "bk", "[Z", "Game/Client", "prayers_on", "[Z", true, false);
+			hookClassVariable(methodNode, "client", "Fc", "[I", "Game/Client", "current_equipment_stats", "[I", true, false);
 			hookClassVariable(methodNode, "client", "oh", "[I", "Game/Client", "current_level", "[I", true, false);
 			hookClassVariable(methodNode, "client", "cg", "[I", "Game/Client", "base_level", "[I", true, false);
 			hookClassVariable(methodNode, "client", "Vk", "[Ljava/lang/String;", "Game/Client", "skill_name", "[Ljava/lang/String;", true, false);

--- a/src/Game/Client.java
+++ b/src/Game/Client.java
@@ -73,6 +73,9 @@ public class Client {
 	public static final int SKILL_AGILITY = 16;
 	public static final int SKILL_THIEVING = 17;
 	
+	public static final int STAT_PRAYER = 4;
+	public static final int[] DRAIN_RATES = { 15, 15, 15, 30, 30, 30, 5, 10, 10, 60, 60, 60, 60, 60 };
+	
 	public static final int STATE_LOGIN = 1;
 	public static final int STATE_GAME = 2;
 	
@@ -123,6 +126,9 @@ public class Client {
 	
 	public static int fatigue;
 	private static float currentFatigue;
+	public static boolean[] prayers_on;
+	// equipment stats (array position 4 holds prayer bonus to determine change drain rate)
+	public static int[] current_equipment_stats;
 	public static int[] current_level;
 	public static int[] base_level;
 	public static int[] xp;


### PR DESCRIPTION
The values are experimental but nonetheless accurate, was getting about 3.1-3.2% for each +1 in prayer equipment status. And the base drain I observed was 1 prayer point per 3.33 seconds.