### PR TITLE
Fix in retro fps overlay, so it doesnt overlap when user is in wild

### DIFF
--- a/src/Game/Client.java
+++ b/src/Game/Client.java
@@ -128,6 +128,7 @@ public class Client {
 	
 	public static long poison_timer = 0L;
 	public static boolean is_poisoned = false;
+	public static boolean is_in_wild;
 	public static int fatigue;
 	private static float currentFatigue;
 	public static boolean[] prayers_on;
@@ -198,6 +199,7 @@ public class Client {
 	
 	public static int selectedItem;
 	public static int selectedItemSlot;
+	public static boolean is_hover;
 	
 	/**
 	 * An array of Strings that stores text used in the client
@@ -970,8 +972,11 @@ public class Client {
 	// hook to display retro fps on the client, early 2001 style
 	public static void retroFPSHook(Object surfaceInstance) {
 		if (surfaceInstance != null && Settings.SHOW_RETRO_FPS) {
+			int offset = 0;
+			if (Client.is_in_wild)
+				offset = 70;
 			try {
-				Reflection.drawString.invoke(surfaceInstance, "Fps: " + Renderer.fps, Renderer.width - 60, Renderer.height - 20, 0xffff00, false, 1);
+				Reflection.drawString.invoke(surfaceInstance, "Fps: " + Renderer.fps, Renderer.width - 62 - offset, Renderer.height - 19, 0xffff00, false, 1);
 			} catch (Exception e) {
 			}
 		}

--- a/src/Game/Renderer.java
+++ b/src/Game/Renderer.java
@@ -646,6 +646,8 @@ public class Renderer {
 				drawShadowText(g2, "replay_client_write: " + Replay.getClientWrite(), x, y, color_text, false);
 				y += 16;
 				drawShadowText(g2, "Last sound effect: " + Client.lastSoundEffect, x, y, color_text, false);
+				y += 16;
+				drawShadowText(g2, "Hover: " + Client.is_hover, x, y, color_text, false);
 			}
 			
 			// A little over a full tick

--- a/src/Game/Replay.java
+++ b/src/Game/Replay.java
@@ -753,7 +753,7 @@ public class Replay {
 			// for the first bytes if byte == (byte)Client.version, 4 bytes before indicate if its
 			// login or reconnect and 5 its what determines if its login-related
 			for (int i = off + 5; i < off + Math.min(15, len); i++) {
-				if (b[i] == (byte)Client.version && b[i - 5] == 0) {
+				if (b[i] == (byte)Client.version && b[i - 5] == 0 && (b[i - 4] == 0 || b[i - 4] == 1)) {
 					isLogin = true;
 					pos = i + 1;
 					out_b = b.clone();


### PR DESCRIPTION
This fixes overlap in retro fps overlay when user is in wild