### PR TITLE
A few bug fixes

### DIFF
--- a/src/Client/ConfigWindow.java
+++ b/src/Client/ConfigWindow.java
@@ -127,6 +127,7 @@ public class ConfigWindow {
   private JSpinner generalPanelClientSizeXSpinner;
   private JSpinner generalPanelClientSizeYSpinner;
   private JCheckBox generalPanelCheckUpdates;
+  private JCheckBox generalPanelWelcomeEnabled;
   // private JCheckBox generalPanelChatHistoryCheckbox;
   private JCheckBox generalPanelCombatXPMenuCheckbox;
   private JCheckBox generalPanelCombatXPMenuHiddenCheckbox;
@@ -503,6 +504,11 @@ public class ConfigWindow {
         addCheckbox("Check for rscplus updates from GitHub at launch", generalPanel);
     generalPanelCheckUpdates.setToolTipText(
         "When enabled, rscplus will check for client updates before launching the game and install them when prompted");
+
+    generalPanelWelcomeEnabled =
+        addCheckbox("Remind you how to open the Settings every time you log in", generalPanel);
+    generalPanelWelcomeEnabled.setToolTipText(
+        "When enabled, rscplus will insert a message telling the current keybinding to open the settings menu and remind you about the tray icon");
 
     generalPanelColoredTextCheckbox = addCheckbox("Colored console text", generalPanel);
     generalPanelColoredTextCheckbox.setToolTipText(
@@ -1876,6 +1882,7 @@ public class ConfigWindow {
     generalPanelClientSizeYSpinner.setValue(
         Settings.CUSTOM_CLIENT_SIZE_Y.get(Settings.currentProfile));
     generalPanelCheckUpdates.setSelected(Settings.CHECK_UPDATES.get(Settings.currentProfile));
+    generalPanelWelcomeEnabled.setSelected(Settings.WELCOME_ENABLED.get(Settings.currentProfile));
     // generalPanelChatHistoryCheckbox.setSelected(Settings.LOAD_CHAT_HISTORY.get(Settings.currentProfile)); // TODO: Implement this feature
     generalPanelCombatXPMenuCheckbox.setSelected(
         Settings.COMBAT_MENU_SHOWN.get(Settings.currentProfile));
@@ -2074,6 +2081,7 @@ public class ConfigWindow {
         Settings.currentProfile,
         ((SpinnerNumberModel) (generalPanelClientSizeYSpinner.getModel())).getNumber().intValue());
     Settings.CHECK_UPDATES.put(Settings.currentProfile, generalPanelCheckUpdates.isSelected());
+    Settings.WELCOME_ENABLED.put(Settings.currentProfile, generalPanelWelcomeEnabled.isSelected());
     // Settings.LOAD_CHAT_HISTORY.put(Settings.currentProfile,
     // generalPanelChatHistoryCheckbox.isSelected());
     Settings.COMBAT_MENU_SHOWN.put(

--- a/src/Client/Settings.java
+++ b/src/Client/Settings.java
@@ -70,6 +70,7 @@ public class Settings {
   public static HashMap<String, Integer> CUSTOM_CLIENT_SIZE_X = new HashMap<String, Integer>();
   public static HashMap<String, Integer> CUSTOM_CLIENT_SIZE_Y = new HashMap<String, Integer>();
   public static HashMap<String, Boolean> CHECK_UPDATES = new HashMap<String, Boolean>();
+  public static HashMap<String, Boolean> WELCOME_ENABLED = new HashMap<String, Boolean>();
   public static HashMap<String, Boolean> LOAD_CHAT_HISTORY = new HashMap<String, Boolean>();
   public static HashMap<String, Boolean> COMBAT_MENU_SHOWN = new HashMap<String, Boolean>();
   public static HashMap<String, Boolean> COMBAT_MENU_HIDDEN = new HashMap<String, Boolean>();
@@ -244,6 +245,15 @@ public class Settings {
     CHECK_UPDATES.put("all", true);
     CHECK_UPDATES.put(
         "custom", getPropBoolean(props, "check_updates", CHECK_UPDATES.get("default")));
+
+    WELCOME_ENABLED.put("vanilla", false);
+    WELCOME_ENABLED.put("vanilla_resizable", false);
+    WELCOME_ENABLED.put("lite", false);
+    WELCOME_ENABLED.put("default", true);
+    WELCOME_ENABLED.put("heavy", true);
+    WELCOME_ENABLED.put("all", true);
+    WELCOME_ENABLED.put(
+        "custom", getPropBoolean(props, "welcome_enabled", WELCOME_ENABLED.get("default")));
 
     LOAD_CHAT_HISTORY.put("vanilla", false);
     LOAD_CHAT_HISTORY.put("vanilla_resizable", false);
@@ -1225,6 +1235,7 @@ public class Settings {
       props.setProperty("custom_client_size_x", Integer.toString(CUSTOM_CLIENT_SIZE_X.get(preset)));
       props.setProperty("custom_client_size_y", Integer.toString(CUSTOM_CLIENT_SIZE_Y.get(preset)));
       props.setProperty("check_updates", Boolean.toString(CHECK_UPDATES.get(preset)));
+      props.setProperty("welcome_enabled", Boolean.toString(WELCOME_ENABLED.get(preset)));
       props.setProperty("load_chat_history", Boolean.toString(LOAD_CHAT_HISTORY.get(preset)));
       props.setProperty("combat_menu", Boolean.toString(COMBAT_MENU_SHOWN.get(preset)));
       props.setProperty("combat_menu_hidden", Boolean.toString(COMBAT_MENU_HIDDEN.get(preset)));

--- a/src/Game/Client.java
+++ b/src/Game/Client.java
@@ -1404,10 +1404,10 @@ public class Client {
       if (username != null) lastpm_username = username;
     }
 
-    if (message.startsWith("Welcome to RuneScape!")) {
+    if (message.startsWith("Welcome to RuneScape!")
+        && Settings.WELCOME_ENABLED.get(Settings.currentProfile)) {
       // because this section of code is triggered when the "Welcome to RuneScape!" message first
-      // appears, we can
-      // use it to do some first time set up
+      // appears, we can use it to do some first time set up
       if (Settings.FIRST_TIME.get(Settings.currentProfile)) {
         Settings.FIRST_TIME.put(Settings.currentProfile, false);
         Settings.save();

--- a/src/Game/Renderer.java
+++ b/src/Game/Renderer.java
@@ -875,7 +875,8 @@ public class Renderer {
         y = Renderer.height - 19;
         int offset = 0;
         if (Client.is_in_wild) offset += 70;
-        if (!screenshot && Replay.isPlaying && Settings.SHOW_SEEK_BAR.get(Settings.currentProfile))
+        if ((!screenshot && Replay.isPlaying && Settings.SHOW_SEEK_BAR.get(Settings.currentProfile))
+                || Settings.SHOW_RETRO_FPS.get(Settings.currentProfile))
           y -= 12;
         if ((!Replay.isPlaying || screenshot)
             && Settings.SHOW_RETRO_FPS.get(Settings.currentProfile)) offset += 70;

--- a/src/Game/XPBar.java
+++ b/src/Game/XPBar.java
@@ -97,6 +97,12 @@ public class XPBar {
 
     int percent = xp * (bounds.width - 2) / xp_needed;
 
+    boolean post99xp = Client.base_level[current_skill] == 99;
+
+    if (percent > bounds.width - 2) { //happens after virtual lvl 100
+      percent = bounds.width - 2;
+    }
+
     int x = xp_bar_x;
     int y = xp_bar_y;
     Renderer.setAlpha(g, alpha);
@@ -106,7 +112,11 @@ public class XPBar {
     g.setColor(Renderer.color_shadow);
     g.fillRect(x, y, bounds.width, bounds.height);
 
-    g.setColor(Renderer.color_hp);
+    if (!post99xp) {
+      g.setColor(Renderer.color_hp);
+    } else {
+      g.setColor(Renderer.color_fatigue);
+    }
     g.fillRect(x + 1, y + 1, percent, bounds.height - 2);
 
     Renderer.drawShadowText(
@@ -126,22 +136,37 @@ public class XPBar {
       y = MouseHandler.y + 16;
       g.setColor(Renderer.color_gray);
       Renderer.setAlpha(g, 0.5f);
-      if (Client.getShowXpPerHour()[current_skill]) g.fillRect(x - 100, y, 200, 60);
-      else g.fillRect(x - 100, y, 200, 36);
+      if (Client.getShowXpPerHour()[current_skill]) {
+        if (!post99xp) {
+          g.fillRect(x - 100, y, 200, 60);
+        } else {
+          g.fillRect(x - 100, y, 200, 48);
+        }
+      } else {
+        g.fillRect(x - 100, y, 200, 36);
+      }
       Renderer.setAlpha(g, 1.0f);
 
       y += 8;
-      Renderer.drawShadowText(
-          g, "XP: " + formatXP(Client.getXP(current_skill)), x, y, Renderer.color_text, true);
-      y += 12;
-      Renderer.drawShadowText(
-          g,
-          "XP until Level: " + formatXP(Client.getXPUntilLevel(current_skill)),
-          x,
-          y,
-          Renderer.color_text,
-          true);
-      y += 12;
+
+      if (!post99xp) {
+        Renderer.drawShadowText(
+                g, "XP: " + formatXP(Client.getXP(current_skill)), x, y, Renderer.color_text, true);
+        y += 12;
+        Renderer.drawShadowText(
+                g,
+                "XP until Level: " + formatXP(Client.getXPUntilLevel(current_skill)),
+                x,
+                y,
+                Renderer.color_text,
+                true);
+        y += 12;
+      } else {
+        y += 8;
+        Renderer.drawShadowText(
+                g, "XP: " + formatXP(Client.getXP(current_skill)), x, y, Renderer.color_text, true);
+        y += 12;
+      }
       if (Client.getShowXpPerHour()[current_skill]) {
         Renderer.drawShadowText(
             g,
@@ -151,18 +176,20 @@ public class XPBar {
             Renderer.color_text,
             true);
         y += 12;
-        Renderer.drawShadowText(
-            g,
-            "Actions until Level: "
-                + formatXP(
-                    Client.getXPUntilLevel(current_skill)
-                        / (Client.getLastXpGain()[current_skill][0]
-                            / (Client.getLastXpGain()[current_skill][3] + 1))),
-            x,
-            y,
-            Renderer.color_text,
-            true);
-        y += 12;
+        if (!post99xp) {
+          Renderer.drawShadowText(
+                  g,
+                  "Actions until Level: "
+                          + formatXP(
+                          Client.getXPUntilLevel(current_skill)
+                                   / (Client.getLastXpGain()[current_skill][0]
+                                  / (Client.getLastXpGain()[current_skill][3] + 1))),
+                  x,
+                  y,
+                  Renderer.color_text,
+                  true);
+          y += 12;
+        }
       }
 
       // Don't allow XP bar to disappear while user is still interacting with it.


### PR DESCRIPTION
closes #144 and #152 and addresses an "authenticity bug": The message that RSC+ injects when it sees the phrase "Welcome to RuneScape!" with chattype none can now be turned off. It was that magenta text reminding the user how to open the settings, and also to let you know if there was an update available.